### PR TITLE
Cache updater wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Implementations are as simple as possible to be predictable in max latency, memo
 
 ## Example
 
-Interface is very simple with three methods: `Set`, `Get`, `Del`:
+Interface is very simple with three methods: `Set`, `Get`, `Del`. Here's a quick example for a ring buffer holding 10k records.
 
 ```go
 package main
@@ -40,6 +40,71 @@ func main() {
 
     fmt.Println(v)
 }
+```
+
+If you intend to use cache in *higlhy* concurrent manner (16+ cores and 100k+ RPS). It may make sense to shard it.
+To shard the cache you need to wrap it using `NewSharded`:
+
+```go
+func main() {
+    // Create sharded TTL cache with number of shards defined automatically
+    // based on number of available CPUs.
+    c := NewSharded[string](
+					func() Geche[string, string] {
+                        return NewMapTTLCache[string, string](ctx, time.Second, time.Second)
+                    },
+					0,
+					&StringMapper{0},
+				)
+
+    c.Set("1", "one")
+    c.Set("2", "dua")
+    c.Del("2")
+    v, err := c.Get("1")
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+
+    fmt.Println(v)
+}
+```
+
+### CacheUpdater
+
+Another useful wrapper is the `CacheUpdater`. It implements a common scenario, when on cache miss some function is called to get the value from external resource (database, API, some lengthy calculation).
+This scenario sounds deceptively simple, but with straightforward implementation can lead to nasty problems like [cache centipede](https://en.wikipedia.org/wiki/Cache_stampede).
+To avoid these types of problems `CacheUpdater` has two limiting mechanisms:
+
+* Pool size limits number of keys that can be updated concurrently. E.g. if you set pool size of 10, your cache update will never run more then 10 simultaneous queries to get the value that was not fount in the cache.
+* In flight mechanism does not allow to call update function to get the value for the key if the update function for this key is already running. E.g. if suddenly 10 requests for the same key hit the cache and miss (key not in the cache), only first will trigger the update, others will just wait for the result.
+
+```go
+    updateFn := func(key string) (string, error) {
+	    return DoSomeDatabaseQuery(key)
+    }
+
+	u := NewCacheUpdater[string, string](
+		NewMapCache[string, string](),
+		updateFn,
+		10,
+	)
+
+    v, err := c.Get("1") // Updater will get value from db here.
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+
+    fmt.Println(v)
+
+    v, err = c.Get("1") // And now the value will be returned from the cache.
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+
+    fmt.Println(v)
 ```
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ func main() {
 ### CacheUpdater
 
 Another useful wrapper is the `CacheUpdater`. It implements a common scenario, when on cache miss some function is called to get the value from external resource (database, API, some lengthy calculation).
-This scenario sounds deceptively simple, but with straightforward implementation can lead to nasty problems like [cache centipede](https://en.wikipedia.org/wiki/Cache_stampede).
+This scenario sounds deceptively simple, but with straightforward implementation can lead to nasty problems like [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede).
 To avoid these types of problems `CacheUpdater` has two limiting mechanisms:
 
 * Pool size limits number of keys that can be updated concurrently. E.g. if you set pool size of 10, your cache update will never run more then 10 simultaneous queries to get the value that was not fount in the cache.

--- a/bench_test.go
+++ b/bench_test.go
@@ -143,8 +143,8 @@ func BenchmarkEverything(b *testing.B) {
 			NewCacheUpdater[string, string](
 				NewSharded[string](
 					func() Geche[string, string] { return NewRingBuffer[string, string](100000) },
-					8,
-					&StringMapper{8},
+					0,
+					&StringMapper{},
 				),
 				updateFn,
 				8,

--- a/bench_test.go
+++ b/bench_test.go
@@ -138,6 +138,18 @@ func BenchmarkEverything(b *testing.B) {
 			"RingBuffer",
 			NewRingBuffer[string, string](1000000),
 		},
+		{
+			"ShardedRingBufferUpdater",
+			NewCacheUpdater[string, string](
+				NewSharded[string](
+					func() Geche[string, string] { return NewRingBuffer[string, string](100000) },
+					8,
+					&StringMapper{8},
+				),
+				updateFn,
+				8,
+			),
+		},
 	}
 
 	data := genTestData(10_000_000)

--- a/common_test.go
+++ b/common_test.go
@@ -116,8 +116,8 @@ func TestCommon(t *testing.T) {
 			"ShardedMapCache", func() Geche[string, string] {
 				return NewSharded[string](
 					func() Geche[string, string] { return NewMapCache[string, string]() },
-					8,
-					&StringMapper{8},
+					0,
+					&StringMapper{},
 				)
 			},
 		},
@@ -125,8 +125,8 @@ func TestCommon(t *testing.T) {
 			"ShardedMapTTLCache", func() Geche[string, string] {
 				return NewSharded[string](
 					func() Geche[string, string] { return NewMapTTLCache[string, string](ctx, time.Second, time.Second) },
-					8,
-					&StringMapper{8},
+					0,
+					&StringMapper{},
 				)
 			},
 		},
@@ -134,8 +134,8 @@ func TestCommon(t *testing.T) {
 			"ShardedRingBuffer", func() Geche[string, string] {
 				return NewSharded[string](
 					func() Geche[string, string] { return NewRingBuffer[string, string](100) },
-					8,
-					&StringMapper{8},
+					0,
+					&StringMapper{},
 				)
 			},
 		},

--- a/shard.go
+++ b/shard.go
@@ -7,24 +7,22 @@ import (
 
 // Mapper maps keys to shards. Good mapper maps them uniformly.
 type Mapper[K any] interface {
-	Map(key K) int
+	Map(key K, numShards int) int
 }
 
 // StringMapper is a simple implementation mapping string keys to N shards.
 // It works best with number of shards that is power of 2, and it
 // works up to 256 shards.
-type StringMapper struct {
-	N int
-}
+type StringMapper struct {}
 
 // Map key to shard number. Should be uniform enough 🤣
-func (sm *StringMapper) Map(key string) int {
+func (sm *StringMapper) Map(key string, numSahrds int) int {
 	var s byte
 	for i := 0; i < len(key); i++ {
 		s ^= key[i]
 	}
 
-	return int(s) % sm.N
+	return int(s) % numSahrds
 }
 
 // Sharded is a wrapper for any Geche interface implementation
@@ -61,15 +59,15 @@ func NewSharded[K comparable, V any](
 }
 
 func (s *Sharded[K, V]) Set(key K, value V) {
-	s.shards[s.mapper.Map(key)].Set(key, value)
+	s.shards[s.mapper.Map(key, s.N)].Set(key, value)
 }
 
 func (s *Sharded[K, V]) Get(key K) (V, error) {
-	return s.shards[s.mapper.Map(key)].Get(key)
+	return s.shards[s.mapper.Map(key, s.N)].Get(key)
 }
 
 func (s *Sharded[K, V]) Del(key K) error {
-	return s.shards[s.mapper.Map(key)].Del(key)
+	return s.shards[s.mapper.Map(key, s.N)].Del(key)
 }
 
 // defaultShardNumber returns recommended number of shards for current CPU.

--- a/updater.go
+++ b/updater.go
@@ -1,0 +1,107 @@
+package geche
+
+import (
+	"sync"
+)
+
+// UpdateFn is a type for a function to be called to get updated value
+// when Updater has a cache miss.
+type UpdateFn[K comparable, V any] func(key K) (V, error)
+
+// Updater is a wrapper on any Geche interface implementation
+// That calls cache update function if key does not exist in the cache.
+// It only allows one Update function per key to be running at a single point of time,
+// reducing odds to get a "cache centipede" situation.
+type Updater[K comparable, V any] struct {
+	cache    Geche[K, V]
+	updateFn UpdateFn[K, V]
+	pool     chan struct{}
+	inFlight map[K]chan struct{}
+	mux      sync.RWMutex
+}
+
+// NewCacheUpdater returns cache wrapped with Updater. It calls updateFn
+// whenever Get function returns ErrNotFound to update cache key.
+// Only one updateFn for a given key can run at the same time, and only
+// poolSize updateFn with different keys san run simultaneously.
+func NewCacheUpdater[K comparable, V any](
+	cache Geche[K, V],
+	updateFn UpdateFn[K, V],
+	poolSize int,
+) *Updater[K, V] {
+	u := Updater[K, V]{
+		cache:    cache,
+		updateFn: updateFn,
+		pool:     make(chan struct{}, poolSize),
+		inFlight: make(map[K]chan struct{}, poolSize),
+	}
+
+	return &u
+}
+
+// checkAndWaitInFlight waits for other cache key update
+// operation to finish. Returns true if had to wait (update operation
+// for key was running).
+func (u *Updater[K, V]) waitInFlight(key K) bool {
+	u.mux.RLock()
+	ch, ok := u.inFlight[key]
+	u.mux.RUnlock()
+
+	if !ok {
+		return false
+	}
+
+	<-ch // Wait for channel to be closed.
+	return true
+}
+
+func (u *Updater[K, V]) Set(key K, value V) {
+	u.cache.Set(key, value)
+}
+
+// Get returns value from the cache. If the value is not in the cache,
+// it calls updateFn to get the value and update the cache first.
+// Since updateFn can return error, Get is not guaranteed to always return the value.
+// When cache update fails, Get will return the error that updateFn returned,
+// and not ErrNotFound.
+func (u *Updater[K, V]) Get(key K) (V, error) {
+	v, err := u.cache.Get(key)
+	// Cache miss - update the cache!
+	if err == ErrNotFound {
+		if u.waitInFlight(key) {
+			// If we had to wait, then other goroutine has already updated
+			// the cache. Returning it.
+			return u.cache.Get(key)
+		}
+
+		// Put token in the pool. Will wait if pool is full.
+		u.pool <- struct{}{}
+		u.mux.Lock()
+		u.inFlight[key] = make(chan struct{})
+		u.mux.Unlock()
+		defer func() {
+			// When finished cache update, releasing all locks.
+			u.mux.Lock()
+			ch, ok := u.inFlight[key]
+			if ok {
+				close(ch)
+				delete(u.inFlight, key)
+			}
+			u.mux.Unlock()
+			<-u.pool
+		}()
+
+		v, err = u.updateFn(key)
+		if err != nil {
+			return v, err
+		}
+
+		u.cache.Set(key, v)
+	}
+
+	return v, err
+}
+
+func (u *Updater[K, V]) Del(key K) error {
+	return u.cache.Del(key)
+}

--- a/updater_test.go
+++ b/updater_test.go
@@ -8,14 +8,14 @@ import (
 	"time"
 )
 
-var theError = errors.New("OOPS! Somebody has dropped the production database!")
+var errThe = errors.New("OOPS! Somebody has dropped the production database")
 
 func updateFn(key string) (string, error) {
 	return key, nil
 }
 
 func updateErrFn(key string) (string, error) {
-	return "", theError
+	return "", errThe
 }
 
 func TestUpdaterScenario(t *testing.T) {
@@ -72,7 +72,7 @@ func TestUpdaterErr(t *testing.T) {
 	)
 
 	_, err := u.Get("test")
-	if err != theError {
+	if err != errThe {
 		t.Errorf("expected to get theError, but got %v", err)
 	}
 

--- a/updater_test.go
+++ b/updater_test.go
@@ -1,0 +1,178 @@
+package geche
+
+import (
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+var theError = errors.New("OOPS! Somebody has dropped the production database!")
+
+func updateFn(key string) (string, error) {
+	return key, nil
+}
+
+func updateErrFn(key string) (string, error) {
+	return "", theError
+}
+
+func TestUpdaterScenario(t *testing.T) {
+	u := NewCacheUpdater[string, string](
+		NewMapCache[string, string](),
+		updateFn,
+		2,
+	)
+
+	v1, err := u.Get("test")
+	if err != nil {
+		t.Errorf("unexpected error in Get: %v", err)
+	}
+
+	v2, err := u.Get("test")
+	if err != nil {
+		t.Errorf("unexpected error in Get: %v", err)
+	}
+
+	if v1 != "test" || v1 != v2 {
+		t.Errorf("expected both values to be %q, but got %q, %q", "test", v1, v2)
+	}
+
+	if err := u.Del("test"); err != nil {
+		t.Errorf("unexpected error in del: %v", err)
+	}
+
+	v, err := u.Get("test")
+	if err != nil {
+		t.Errorf("unexpected error in Get: %v", err)
+	}
+
+	if v != "test" {
+		t.Errorf("expected to get %q, but got %q", "test", v)
+	}
+
+	u.Set("test", "best")
+
+	v3, err := u.Get("test")
+	if err != nil {
+		t.Errorf("unexpected error in Get: %v", err)
+	}
+
+	if v3 != "best" {
+		t.Errorf("expected to get %q, but got %q", "best", v3)
+	}
+}
+
+func TestUpdaterErr(t *testing.T) {
+	u := NewCacheUpdater[string, string](
+		NewMapCache[string, string](),
+		updateErrFn,
+		2,
+	)
+
+	_, err := u.Get("test")
+	if err != theError {
+		t.Errorf("expected to get theError, but got %v", err)
+	}
+
+	u.Set("test", "test")
+
+	v, err := u.Get("test")
+	if err != nil {
+		t.Errorf("unexpected error in Get: %v", err)
+	}
+
+	if v != "test" {
+		t.Errorf("expected to get %q, but got %q", "test", v)
+	}
+}
+
+func TestUpdaterConcurrent(t *testing.T) {
+	var (
+		mux     sync.Mutex
+		currCnt int
+		peakCnt int
+	)
+
+	updateFn := func(key string) (string, error) {
+		mux.Lock()
+		currCnt++
+		if currCnt > peakCnt {
+			peakCnt = currCnt
+		}
+		mux.Unlock()
+
+		defer func() {
+			mux.Lock()
+			currCnt--
+			mux.Unlock()
+		}()
+
+		time.Sleep(time.Millisecond)
+		return key, nil
+	}
+
+	poolSize := 4
+
+	u := NewCacheUpdater[string, string](
+		NewMapCache[string, string](),
+		updateFn,
+		poolSize,
+	)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1000)
+	for i := 0; i < 1000; i++ {
+		go func() {
+			defer wg.Done()
+			v, err := u.Get("test")
+			if err != nil {
+				t.Errorf("unexpected error in Get: %v", err)
+			}
+
+			if v != "test" {
+				t.Errorf("expected to get %q, but got %q", "test", v)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if currCnt != 0 {
+		t.Errorf("expected currCnt to be 0, got %d", currCnt)
+	}
+
+	// We are using one key, so peakCnt s(hould be 1.
+	if peakCnt != 1 {
+		t.Errorf("expected peakCnt to be %d, got %d", 1, peakCnt)
+	}
+
+	wg = sync.WaitGroup{}
+	wg.Add(1000)
+	for i := 0; i < 1000; i++ {
+		go func(i int) {
+			defer wg.Done()
+			key := strconv.Itoa(i % 100)
+			v, err := u.Get(key)
+			if err != nil {
+				t.Errorf("unexpected error in Get: %v", err)
+			}
+
+			if v != key {
+				t.Errorf("expected to get %q, but got %q", key, v)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	if currCnt != 0 {
+		t.Errorf("expected currCnt to be 0, got %d", currCnt)
+	}
+
+	// For 100 distinct keys peakCnt should be limited to poolSize.
+	if peakCnt != poolSize {
+		t.Errorf("expected peakCnt to be %d, got %d", poolSize, peakCnt)
+	}
+}


### PR DESCRIPTION
`CacheUpdater` implements a common scenario, when on cache miss some function is called to get the value from external resource (database, API, some lengthy calculation).
This scenario sounds deceptively simple, but with straightforward implementation can lead to nasty problems like [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede).
To avoid these types of problems `CacheUpdater` has two limiting mechanisms:

* Pool size limits number of keys that can be updated concurrently. E.g. if you set pool size of 10, your cache update will never run more then 10 simultaneous queries to get the value that was not found in the cache.
* In-flight mechanism does not allow to call update function to get the value for the key if the update function for this key is already running. E.g. if suddenly 10 requests for the same key hit the cache and miss (key is not in the cache), only the first one will trigger the update and others will just wait for the result.