### PR TITLE
Add Snapshot and Len functions, NumberMapper for Sharded

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ func main() {
 ```
 
 If you intend to use cache in *higlhy* concurrent manner (16+ cores and 100k+ RPS). It may make sense to shard it.
-To shard the cache you need to wrap it using `NewSharded`:
+To shard the cache you need to wrap it using `NewSharded`. Sharded cache will determine to which shard the value should go using a mapper that implements interface with `Map(key K, numShards int) int` function. The point of this function is to uniformly map keys to provided number of shards.
 
 ```go
 func main() {
@@ -69,6 +69,15 @@ func main() {
     fmt.Println(v)
 }
 ```
+
+Sometimes it is useful to get snapshot of the whole cache (e.g. to avoid cold cache on service restart).
+All cache implementations have `Snapshot() map[K]V` function that aquires ReadLock, copies the cache content to the map and returns it.
+Please be aware that it is a shallow copy, so if your cache value type contains reference types, it may be unsafe to modify the returned copy.
+
+```go
+
+```
+
 
 ### CacheUpdater
 

--- a/common_test.go
+++ b/common_test.go
@@ -39,6 +39,49 @@ func testDel(t *testing.T, imp Geche[string, string]) {
 	}
 }
 
+func testSnapshotLen(t *testing.T, imp Geche[string, string]) {
+	expected := map[string]string{}
+	for i := 0; i < 100; i++ {
+		s := strconv.Itoa(i)
+		imp.Set(s, s)
+		expected[s] = s
+	}
+
+	if imp.Len() != 100 {
+		t.Errorf("expected length %d, got %d", 100, imp.Len())
+	}
+
+	for _, i := range []int{0, 13, 42, 69, 99} {
+		s := strconv.Itoa(i)
+		imp.Del(s)
+		delete(expected, s)
+	}
+
+	got := imp.Snapshot()
+
+	if imp.Len() != 95 {
+		t.Errorf("expected length %d, got %d", 95, imp.Len())
+	}
+
+	for k, v := range expected {
+		gv, ok := got[k]
+		if !ok {
+			t.Errorf("expected key %q not found in snapshot", k)
+		}
+
+		if gv != v {
+			t.Errorf("expected value %q, got %q", v, gv)
+		}
+	}
+
+	for k, v := range got {
+		_, ok := expected[k]
+		if !ok {
+			t.Errorf("unexpected key %q with value %q found in snapshot", k, v)
+		}
+	}
+}
+
 func testDelOdd(t *testing.T, imp Geche[string, string]) {
 	for i := 0; i < 100; i++ {
 		s := strconv.Itoa(i)
@@ -149,6 +192,7 @@ func TestCommon(t *testing.T) {
 		{"GetNonExist", testGetNonExist},
 		{"Del", testDel},
 		{"DelOdd", testDelOdd},
+		{"SnapshotLen", testSnapshotLen},
 	}
 	for _, ci := range caches {
 		for _, tc := range tab {

--- a/common_test.go
+++ b/common_test.go
@@ -53,7 +53,9 @@ func testSnapshotLen(t *testing.T, imp Geche[string, string]) {
 
 	for _, i := range []int{0, 13, 42, 69, 99} {
 		s := strconv.Itoa(i)
-		imp.Del(s)
+		if err := imp.Del(s); err != nil {
+			t.Errorf("unexpected error in Del: %v", err)
+		}
 		delete(expected, s)
 	}
 

--- a/doc.go
+++ b/doc.go
@@ -6,8 +6,11 @@ import "errors"
 
 var ErrNotFound = errors.New("not found")
 
+// Geche interface is a common interface for all cache implementations.
 type Geche[K comparable, V any] interface {
 	Set(K, V)
 	Get(K) (V, error)
 	Del(K) error
+	Snapshot() map[K]V
+	Len() int
 }

--- a/dummy_test.go
+++ b/dummy_test.go
@@ -20,18 +20,18 @@ func newStringCache() *stringCache {
 	}
 }
 
-func (c *stringCache) Set(key, value string) {
-	c.mux.Lock()
-	defer c.mux.Unlock()
+func (s *stringCache) Set(key, value string) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 
-	c.data[key] = value
+	s.data[key] = value
 }
 
-func (c *stringCache) Get(key string) (string, error) {
-	c.mux.RLock()
-	defer c.mux.RUnlock()
+func (s *stringCache) Get(key string) (string, error) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
 
-	v, ok := c.data[key]
+	v, ok := s.data[key]
 	if !ok {
 		return v, ErrNotFound
 	}
@@ -39,13 +39,22 @@ func (c *stringCache) Get(key string) (string, error) {
 	return v, nil
 }
 
-func (c *stringCache) Del(key string) error {
-	c.mux.Lock()
-	defer c.mux.Unlock()
+func (s *stringCache) Del(key string) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 
-	delete(c.data, key)
+	delete(s.data, key)
 
 	return nil
+}
+
+func (s *stringCache) Snapshot() map[string]string { return nil }
+
+func (s *stringCache) Len() int {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+
+	return len(s.data)
 }
 
 type unsafeCache struct {
@@ -58,12 +67,12 @@ func newUnsafeCache() *unsafeCache {
 	}
 }
 
-func (c *unsafeCache) Set(key, value string) {
-	c.data[key] = value
+func (u *unsafeCache) Set(key, value string) {
+	u.data[key] = value
 }
 
-func (c *unsafeCache) Get(key string) (string, error) {
-	v, ok := c.data[key]
+func (u *unsafeCache) Get(key string) (string, error) {
+	v, ok := u.data[key]
 	if !ok {
 		return v, ErrNotFound
 	}
@@ -71,10 +80,16 @@ func (c *unsafeCache) Get(key string) (string, error) {
 	return v, nil
 }
 
-func (c *unsafeCache) Del(key string) error {
-	delete(c.data, key)
+func (u *unsafeCache) Del(key string) error {
+	delete(u.data, key)
 
 	return nil
+}
+
+func (u *unsafeCache) Snapshot() map[string]string { return nil }
+
+func (u *unsafeCache) Len() int {
+	return len(u.data)
 }
 
 type anyCache struct {
@@ -88,18 +103,18 @@ func newAnyCache() *anyCache {
 	}
 }
 
-func (c *anyCache) Set(key string, value any) {
-	c.mux.Lock()
-	defer c.mux.Unlock()
+func (a *anyCache) Set(key string, value any) {
+	a.mux.Lock()
+	defer a.mux.Unlock()
 
-	c.data[key] = value
+	a.data[key] = value
 }
 
-func (c *anyCache) Get(key string) (any, error) {
-	c.mux.RLock()
-	defer c.mux.RUnlock()
+func (a *anyCache) Get(key string) (any, error) {
+	a.mux.RLock()
+	defer a.mux.RUnlock()
 
-	v, ok := c.data[key]
+	v, ok := a.data[key]
 	if !ok {
 		return v, ErrNotFound
 	}
@@ -107,8 +122,17 @@ func (c *anyCache) Get(key string) (any, error) {
 	return v, nil
 }
 
-func (c *anyCache) Del(key string) error {
-	delete(c.data, key)
+func (a *anyCache) Del(key string) error {
+	delete(a.data, key)
 
 	return nil
+}
+
+func (a *anyCache) Snapshot() map[string]any { return nil }
+
+func (a *anyCache) Len() int {
+	a.mux.RLock()
+	defer a.mux.RUnlock()
+
+	return len(a.data)
 }

--- a/map.go
+++ b/map.go
@@ -38,6 +38,7 @@ func (c *MapCache[K, V]) Get(key K) (V, error) {
 	return v, nil
 }
 
+// Del removes key from the cache. Return value is always nil.
 func (c *MapCache[K, V]) Del(key K) error {
 	c.mux.Lock()
 	defer c.mux.Unlock()
@@ -45,4 +46,26 @@ func (c *MapCache[K, V]) Del(key K) error {
 	delete(c.data, key)
 
 	return nil
+}
+
+// Snapshot returns a shallow copy of the cache data.
+// Locks the cache from modification for the duration of the copy.
+func (c *MapCache[K, V]) Snapshot() map[K]V {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+
+	snapshot := make(map[K]V, len(c.data))
+	for k, v := range c.data {
+		snapshot[k] = v
+	}
+
+	return snapshot
+}
+
+// Len returns number of items in the cache.
+func (c *MapCache[K, V]) Len() int {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+
+	return len(c.data)
 }

--- a/map_ttl.go
+++ b/map_ttl.go
@@ -192,3 +192,26 @@ func (c *MapTTLCache[K, V]) cleanup() error {
 
 	return nil
 }
+
+// Snapshot returns a shallow copy of the cache data.
+// Locks the cache from modification for the duration of the copy.
+func (c *MapTTLCache[K, V]) Snapshot() map[K]V {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+
+	snapshot := make(map[K]V, len(c.data))
+	for k, v := range c.data {
+		snapshot[k] = v.value
+	}
+
+	return snapshot
+}
+
+
+// Len returns the number of records in the cache.
+func (c *MapTTLCache[K, V]) Len() int {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+
+	return len(c.data)
+}

--- a/shard.go
+++ b/shard.go
@@ -5,24 +5,36 @@ import (
 	"runtime"
 )
 
+type integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
 // Mapper maps keys to shards. Good mapper maps them uniformly.
 type Mapper[K any] interface {
 	Map(key K, numShards int) int
 }
 
+// NumberMapper maps integer keys to N shards using modulo operation.
+type NumberMapper[K integer] struct{}
+
+// Map key to shard number.
+func (nm *NumberMapper[K]) Map(key K, numShards int) int {
+	return int(uint64(key) % uint64(numShards))
+}
+
 // StringMapper is a simple implementation mapping string keys to N shards.
 // It works best with number of shards that is power of 2, and it
 // works up to 256 shards.
-type StringMapper struct {}
+type StringMapper struct{}
 
 // Map key to shard number. Should be uniform enough 🤣
-func (sm *StringMapper) Map(key string, numSahrds int) int {
+func (sm *StringMapper) Map(key string, numShards int) int {
 	var s byte
 	for i := 0; i < len(key); i++ {
 		s ^= key[i]
 	}
 
-	return int(s) % numSahrds
+	return int(s) % numShards
 }
 
 // Sharded is a wrapper for any Geche interface implementation
@@ -58,16 +70,33 @@ func NewSharded[K comparable, V any](
 	return &s
 }
 
+// Set key-value pair in the underlying sharded cache.
 func (s *Sharded[K, V]) Set(key K, value V) {
 	s.shards[s.mapper.Map(key, s.N)].Set(key, value)
 }
 
+// Get value by key from the underlying sharded cache.
 func (s *Sharded[K, V]) Get(key K) (V, error) {
 	return s.shards[s.mapper.Map(key, s.N)].Get(key)
 }
 
+// Del key from the underlying sharded cache.
 func (s *Sharded[K, V]) Del(key K) error {
 	return s.shards[s.mapper.Map(key, s.N)].Del(key)
+}
+
+// Snapshot returns a shallow copy of the cache data.
+// Sequentially locks each of she undelnying shards
+// from modification for the duration of the copy.
+func (s *Sharded[K, V]) Snapshot() map[K]V {
+	snapshot := make(map[K]V)
+	for _, shard := range s.shards {
+		for k, v := range shard.Snapshot() {
+			snapshot[k] = v
+		}
+	}
+
+	return snapshot
 }
 
 // defaultShardNumber returns recommended number of shards for current CPU.
@@ -75,4 +104,14 @@ func (s *Sharded[K, V]) Del(key K) error {
 // number of available CPU cores.
 func defaultShardNumber() int {
 	return 1 << (int(math.Ceil(math.Log2(float64(runtime.NumCPU())))))
+}
+
+// Len returns total number of elements in the underlying sharded caches.
+func (s *Sharded[K, V]) Len() int {
+	var l int
+	for _, shard := range s.shards {
+		l += shard.Len()
+	}
+
+	return l
 }

--- a/shard_test.go
+++ b/shard_test.go
@@ -1,0 +1,37 @@
+package geche
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestSharded(t *testing.T) {
+	c := NewSharded[int](
+		func() Geche[int, string] {
+			return NewMapCache[int, string]()
+		},
+		4,
+		&NumberMapper[int]{},
+	)
+
+	for i := 0; i < 1000; i++ {
+		c.Set(i, strconv.Itoa(i))
+	}
+
+	for i := 0; i < 1000; i++ {
+		v, err := c.Get(i)
+		if err != nil {
+			t.Fatalf("unexpected error in Get: %v", err)
+		}
+
+		if v != strconv.Itoa(i) {
+			t.Fatalf("key %d with unexpected value %q", i, v)
+		}
+	}
+
+	if len(c.shards) != 4 {
+		t.Errorf("expected number of shards to be 4 but got %d", len(c.shards))
+	}
+
+	
+}

--- a/updater.go
+++ b/updater.go
@@ -102,6 +102,18 @@ func (u *Updater[K, V]) Get(key K) (V, error) {
 	return v, err
 }
 
+// Del deletes key from the cache.
 func (u *Updater[K, V]) Del(key K) error {
 	return u.cache.Del(key)
+}
+
+// Snapshot returns a shallow copy of the cache.
+// It locks the cache from modification for the duration of the copy.
+func (u *Updater[K, V]) Snapshot() map[K]V {
+	return u.cache.Snapshot()
+}
+
+// Len returns the number of items in the cache.
+func (u *Updater[K, V]) Len() int {
+	return u.cache.Len()
 }

--- a/updater_test.go
+++ b/updater_test.go
@@ -25,6 +25,10 @@ func TestUpdaterScenario(t *testing.T) {
 		2,
 	)
 
+	if u.Len() != 0 {
+		t.Errorf("expected length to be 0, but got %d", u.Len())
+	}
+
 	v1, err := u.Get("test")
 	if err != nil {
 		t.Errorf("unexpected error in Get: %v", err)
@@ -37,6 +41,10 @@ func TestUpdaterScenario(t *testing.T) {
 
 	if v1 != "test" || v1 != v2 {
 		t.Errorf("expected both values to be %q, but got %q, %q", "test", v1, v2)
+	}
+
+	if u.Len() != 1 {
+		t.Errorf("expected length to be 1, but got %d", u.Len())
 	}
 
 	if err := u.Del("test"); err != nil {
@@ -61,6 +69,15 @@ func TestUpdaterScenario(t *testing.T) {
 
 	if v3 != "best" {
 		t.Errorf("expected to get %q, but got %q", "best", v3)
+	}
+
+	s := u.Snapshot()
+	if len(s) != 1 {
+		t.Errorf("expected snapshot length to be 1, but got %d", len(s))
+	}
+
+	if s["test"] != "best" {
+		t.Errorf("expected to get %q, but got %q", "best", s["test"])
 	}
 }
 


### PR DESCRIPTION
Added a couple of convinience functions:
* `Snapshot() map[K]V` to get a copy of key-value data from the cache as a `map[K]V`.
* `Len() int` to return size of the cache (including not-yet evicted values).