### PR TITLE
Feature/get by prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Collection of generic cache implementations in Go focused on simplicity. No clev
 Implementations are as simple as possible to be predictable in max latency, memory allocation and concurrency impact (writes lock reads and are serialized with other writes).
 
 * `MapCache` is a very simple map-based thread-safe cache, that is not limited from growing. Can be used when you have relatively small number of distinct keys that does not grow significantly, and you do not need the values to expire automatically. E.g. if your keys are country codes, timezones etc, this cache type is ok to use.
-* `MapTTLCache` is map-based thread-safe cache with support for TTL (values automatically expire). If you don't want to read value from cache that is older then some threshold (e.g. 1 sec), you set this TTL when initializing the cache object and obsolete rows will be removed from cache automatically.
+* `MapTTLCache` is map-based thread-safe cache with support for TTL (values automatically expire). If you don't want to read value from cache that is older than some threshold (e.g. 1 sec), you set this TTL when initializing the cache object and obsolete rows will be removed from cache automatically.
 * `RingBuffer` is a predefined size cache that allocates all memory from the start and will not grow above it. It keeps constant size by overwriting the oldest values in the cache with new ones. Use this cache when you need speed and fixed memory footprint, and your key cardinality is predictable (or you are ok with having cache misses if cardinality suddenly grows above your cache size).
 
 ## Example
@@ -120,7 +120,7 @@ fmt.Println(v)
 
 Test suite contains a couple of benchmarks to compare the speed difference between old-school generic implementation using `interface{}` or `any` to hold cache values versus using generics.
 
-TL/DR: generics are faster than `interface{}` but slower than hardcoded type implementation. Ring buffer is 2x+ faster then map-based TTL cache.
+TL/DR: generics are faster than `interface{}` but slower than hardcoded type implementation. Ring buffer is 2x+ faster than map-based TTL cache.
 
 There are two types of benchmarks:
 * `BenchmarkSet` only times the `Set` operation that allocates all the memory, and usually is the most resource intensive.

--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ If your use-case requires not only random but also sequential access to values i
 
 Another useful trick is to use `ListByPrefix("")` to get all values in the cache as a slice ordered by key.
 
-```go
-
 Internally `KV` maintains trie structure to store keys to be able to quickly find all keys with the same prefix. This trie is updated on every `Set` and `Del` operation, so it is not free both in terms of CPU and memory consumption. If you don't need `ListByPrefix` functionality, don't use this wrapper.
 
 This wrapper has some limitations:
@@ -145,7 +143,18 @@ This wrapper has some limitations:
 * If you wrap `KV` with another wrapper you can't use `ListByPrefix`. Don't do it!
 
 ```go
+func main() {
+    c := NewKV[string](NewMapCache[string, string]())
 
+    c.Set("testB", "value B")
+    c.Set("testA", "value A")
+    c.Del("best")
+    v, _ := c.ListByPrefix("test")
+
+    // Will output [value A value B]
+    fmt.Println(v)
+}
+```
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -143,17 +143,17 @@ This wrapper has some limitations:
 * If you wrap `KV` with another wrapper you can't use `ListByPrefix`. Don't do it!
 
 ```go
-func main() {
-    c := NewKV[string](NewMapCache[string, string]())
+	cache := NewMapCache[string, string]()
+	kv := NewKV[string](cache)
 
-    c.Set("testB", "value B")
-    c.Set("testA", "value A")
-    c.Del("best")
-    v, _ := c.ListByPrefix("test")
+	kv.Set("foo", "bar")
+	kv.Set("foo2", "bar2")
+	kv.Set("foo3", "bar3")
+	kv.Set("foo1", "bar1")
 
-    // Will output [value A value B]
-    fmt.Println(v)
-}
+	res, _ := kv.ListByPrefix("foo")
+	fmt.Println(res)
+	// Output: [bar bar1 bar2 bar3]
 ```
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -218,29 +218,32 @@ PASS
 ok      cache_bench     496.390s
 ```
 
-And now on 96 CPU machine we clearly see performance degradation due to lock contention. Sharded implementations are about 4 times faster.
+And now on 32 CPU machine we clearly see performance degradation due to lock contention. Sharded implementations are about 4 times faster.
 Notice the Imcache result. Is too good to be true 😅
 
-```
-go test -bench . -benchtime=30s
+KV wrapper result is worse then other caches, but it is expected as it keeps key level ordering on insert and does extra work to cleanup the key in trie on delete.
+
+```shell
+$ go test -benchtime=10s -benchmem -bench .
 goos: linux
 goarch: amd64
 pkg: cache_bench
-cpu: Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
-BenchmarkEverythingParallel/MapCache-96         	170261677	       237.8 ns/op
-BenchmarkEverythingParallel/MapTTLCache-96      	142511408	       272.9 ns/op
-BenchmarkEverythingParallel/RingBuffer-96       	173581318	       230.8 ns/op
-BenchmarkEverythingParallel/ShardedMapCache-96  	572037444	        56.76 ns/op
-BenchmarkEverythingParallel/ShardedMapTTLCache-96         	607333974	        58.35 ns/op
-BenchmarkEverythingParallel/ShardedRingBuffer-96          	599080330	        52.26 ns/op
-BenchmarkEverythingParallel/github.com/Code-Hex/go-generics-cache-96         	148365510	       263.4 ns/op
-BenchmarkEverythingParallel/github.com/Yiling-J/theine-go-96                 	289192544	       122.9 ns/op
-BenchmarkEverythingParallel/github.com/jellydator/ttlcache-96                	101329562	       383.6 ns/op
-BenchmarkEverythingParallel/github.com/erni27/imcache-96                     	1000000000	        12.09 ns/op
-BenchmarkEverythingParallel/github.com/dgraph-io/ristretto-96                	322868853	       111.6 ns/op
-BenchmarkEverythingParallel/github.com/hashicorp/golang-lru/v2-96            	145826460	       259.8 ns/op
+cpu: Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz
+BenchmarkEverythingParallel/MapCache-32         	64085875	       248.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEverythingParallel/MapTTLCache-32      	58598002	       279.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEverythingParallel/RingBuffer-32       	48229945	       315.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEverythingParallel/ShardedMapCache-32  	234258486	        53.16 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEverythingParallel/ShardedMapTTLCache-32         	231177732	        53.63 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEverythingParallel/ShardedRingBuffer-32          	236979438	        48.98 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEverythingParallel/github.com/Code-Hex/go-generics-cache-32         	39842918	       345.9 ns/op	       7 B/op	       0 allocs/op
+BenchmarkEverythingParallel/github.com/Yiling-J/theine-go-32                 	150612642	        81.82 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEverythingParallel/github.com/jellydator/ttlcache-32                	29333647	       433.9 ns/op	      43 B/op	       0 allocs/op
+BenchmarkEverythingParallel/github.com/erni27/imcache-32                     	345577933	        35.63 ns/op	      50 B/op	       1 allocs/op
+BenchmarkEverythingParallel/github.com/dgraph-io/ristretto-32                	83293519	       142.1 ns/op	      27 B/op	       1 allocs/op
+BenchmarkEverythingParallel/github.com/hashicorp/golang-lru/v2-32            	35763888	       378.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkEverythingParallel/github.com/egregors/kesh-32                      	25860772	       524.1 ns/op	      84 B/op	       2 allocs/op
+BenchmarkEverythingParallel/KVMapCache-32                                    	33802629	       478.4 ns/op	     109 B/op	       0 allocs/op
 PASS
-ok  	cache_bench	608.617s
 ```
 
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -155,8 +155,8 @@ func BenchmarkEverything(b *testing.B) {
 			),
 		},
 		{
-			"KVRingBufferCache",
-			NewKV[string](NewRingBuffer[string, string](1000000)),
+			"KVMapCache",
+			NewKV[string](NewMapCache[string, string]()),
 		},
 	}
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -90,6 +90,10 @@ func BenchmarkSet(b *testing.B) {
 			"RingBuffer",
 			NewRingBuffer[string, string](1000000),
 		},
+		{
+			"KVMapCache",
+			NewKV[string](NewMapCache[string, string]()),
+		},
 	}
 
 	data := genTestData(10_000_000)
@@ -149,6 +153,10 @@ func BenchmarkEverything(b *testing.B) {
 				updateFn,
 				8,
 			),
+		},
+		{
+			"KVRingBufferCache",
+			NewKV[string](NewRingBuffer[string, string](1000000)),
 		},
 	}
 

--- a/common_test.go
+++ b/common_test.go
@@ -135,6 +135,7 @@ func testDelOdd(t *testing.T, imp Geche[string, string]) {
 		}
 	}
 
+	// Del is idempotent. Should not return error for non-existing keys.
 	if err := imp.Del("key"); err != nil {
 		t.Errorf("unexpected error in Del: %v", err)
 	}
@@ -157,6 +158,7 @@ func TestCommon(t *testing.T) {
 		{"MapCache", func() Geche[string, string] { return NewMapCache[string, string]() }},
 		{"MapTTLCache", func() Geche[string, string] { return NewMapTTLCache[string, string](ctx, time.Minute, time.Minute) }},
 		{"RingBuffer", func() Geche[string, string] { return NewRingBuffer[string, string](100) }},
+		{"KVMapCache", func() Geche[string, string] { return NewKV[string](NewMapCache[string, string]()) }},
 		{
 			"ShardedMapCache", func() Geche[string, string] {
 				return NewSharded[string](

--- a/kv.go
+++ b/kv.go
@@ -33,9 +33,6 @@ func (kv *KV[V]) Set(key string, value V) {
 	defer kv.mux.Unlock()
 
 	kv.data.Set(key, value)
-	if key == "" {
-		return
-	}
 
 	node := kv.trie
 	for i := 0; i < len(key); i++ {

--- a/kv.go
+++ b/kv.go
@@ -90,12 +90,12 @@ func (kv *KV[V]) ListByPrefix(prefix string) ([]V, error) {
 	return kv.dfs(node, []byte(prefix))
 }
 
-// Get value by key from the underlying sharded cache.
+// Get value by key from the underlying cache.
 func (kv *KV[V]) Get(key string) (V, error) {
 	return kv.data.Get(key)
 }
 
-// Del key from the underlying sharded cache.
+// Del key from the underlying cache.
 func (kv *KV[V]) Del(key string) error {
 	kv.mux.Lock()
 	defer kv.mux.Unlock()
@@ -136,7 +136,7 @@ func (kv *KV[V]) Snapshot() map[string]V {
 	return kv.data.Snapshot()
 }
 
-// Len returns total number of elements in the underlying sharded caches.
+// Len returns total number of elements in the underlying caches.
 func (kv *KV[V]) Len() int {
 	return kv.data.Len()
 }

--- a/kv.go
+++ b/kv.go
@@ -1,0 +1,89 @@
+package geche
+
+import (
+	"math"
+	"runtime"
+)
+
+type trieNode struct {
+	c byte
+	next [256]*trieNode
+	terminal bool
+}
+
+type KV[V any] struct {
+	data Geche[string, V]
+	trie *trieNode
+}
+
+func NewKV[V any](
+	cache Geche[string, V],
+) *KV[V] {
+	kv := KV[V]{
+		data: cache,
+	}
+
+	return &kv
+}
+
+// Set key-value pair in the underlying sharded cache.
+func (kv *KV[V]) Set(key string, value V) {
+	kv.data.Set(key, value)
+	if key == "" {
+		return
+	}
+
+	node := kv.trie
+	for i := 0; i < len(key); i++ {
+		next := node.next[key[i]]
+		if next == nil {
+			next = new(trieNode)
+			node.next[key[i]] = next
+		}
+
+		node = next
+	}
+
+	node.terminal = true
+}
+
+
+func (kv *KV[V]) GetByPrefix(prefix string) ([]V, error) {
+	res := []V{}
+
+	node := kv.trie
+	for i := 0; i < len(prefix); i++ {
+		next := node.next[prefix[i]]
+		if next == nil {
+			return res, nil
+		}
+		node = next
+	}
+
+	
+
+	return res, nil
+}
+
+
+// Get value by key from the underlying sharded cache.
+func (kv *KV[V]) Get(key string) (V, error) {
+	return kv.data.Get(key)
+}
+
+// Del key from the underlying sharded cache.
+func (kv *KV[V]) Del(key string) error {
+	return kv.data.Del(key)
+}
+
+// Snapshot returns a shallow copy of the cache data.
+// Sequentially locks each of she undelnying shards
+// from modification for the duration of the copy.
+func (kv *KV[V]) Snapshot() map[string]V {
+	return kv.data.Snapshot()
+}
+
+// Len returns total number of elements in the underlying sharded caches.
+func (kv *KV[V]) Len() int {
+	return kv.data.Len()
+}

--- a/kv.go
+++ b/kv.go
@@ -1,19 +1,19 @@
 package geche
 
 import (
-	"math"
-	"runtime"
+	"sync"
 )
 
 type trieNode struct {
-	c byte
-	next [256]*trieNode
+	c        byte
+	next     [256]*trieNode
 	terminal bool
 }
 
 type KV[V any] struct {
 	data Geche[string, V]
 	trie *trieNode
+	mux  sync.RWMutex
 }
 
 func NewKV[V any](
@@ -21,13 +21,17 @@ func NewKV[V any](
 ) *KV[V] {
 	kv := KV[V]{
 		data: cache,
+		trie: new(trieNode),
 	}
 
 	return &kv
 }
 
-// Set key-value pair in the underlying sharded cache.
+// Set key-value pair while updating the trie.
 func (kv *KV[V]) Set(key string, value V) {
+	kv.mux.Lock()
+	defer kv.mux.Unlock()
+
 	kv.data.Set(key, value)
 	if key == "" {
 		return
@@ -37,7 +41,9 @@ func (kv *KV[V]) Set(key string, value V) {
 	for i := 0; i < len(key); i++ {
 		next := node.next[key[i]]
 		if next == nil {
-			next = new(trieNode)
+			next = &trieNode{
+				c: key[i],
+			}
 			node.next[key[i]] = next
 		}
 
@@ -47,24 +53,45 @@ func (kv *KV[V]) Set(key string, value V) {
 	node.terminal = true
 }
 
-
-func (kv *KV[V]) GetByPrefix(prefix string) ([]V, error) {
+func (kv *KV[V]) dfs(node *trieNode, prefix []byte) ([]V, error) {
 	res := []V{}
+	if node.terminal {
+		val, err := kv.data.Get(string(prefix))
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, val)
+	}
+
+	for i := 0; i < len(node.next); i++ {
+		if node.next[i] != nil {
+			next := node.next[i]
+			nextRes, err := kv.dfs(next, append(prefix, next.c))
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, nextRes...)
+		}
+	}
+
+	return res, nil
+}
+
+func (kv *KV[V]) ListByPrefix(prefix string) ([]V, error) {
+	kv.mux.RLock()
+	defer kv.mux.RUnlock()
 
 	node := kv.trie
 	for i := 0; i < len(prefix); i++ {
 		next := node.next[prefix[i]]
 		if next == nil {
-			return res, nil
+			return nil, nil
 		}
 		node = next
 	}
 
-	
-
-	return res, nil
+	return kv.dfs(node, []byte(prefix))
 }
-
 
 // Get value by key from the underlying sharded cache.
 func (kv *KV[V]) Get(key string) (V, error) {
@@ -73,6 +100,35 @@ func (kv *KV[V]) Get(key string) (V, error) {
 
 // Del key from the underlying sharded cache.
 func (kv *KV[V]) Del(key string) error {
+	kv.mux.Lock()
+	defer kv.mux.Unlock()
+
+	node := kv.trie
+	var prev *trieNode
+	for i := 0; i < len(key); i++ {
+		next := node.next[key[i]]
+		if next == nil {
+			return nil
+		}
+
+		prev = node
+		node = next
+	}
+
+	node.terminal = false
+
+	empty := true
+	for i := 0; i < len(node.next); i++ {
+		if node.next[i] != nil {
+			empty = false
+			break
+		}
+	}
+
+	if empty {
+		prev.next[node.c] = nil
+	}
+
 	return kv.data.Del(key)
 }
 

--- a/kv_test.go
+++ b/kv_test.go
@@ -1,0 +1,123 @@
+package geche
+
+import (
+	"fmt"
+	"testing"
+)
+
+func compareSlice(t *testing.T, exp, got []string) {
+	t.Helper()
+
+	t.Log(got)
+	if len(exp) != len(got) {
+		t.Fatalf("expected length %d, got %d", len(exp), len(got))
+	}
+
+	for i := 0; i < len(exp); i++ {
+		if exp[i] != got[i] {
+			t.Errorf("expected %q, got %q", exp[i], got[i])
+		}
+	}
+}
+
+func TestKV(t *testing.T) {
+	cache := NewMapCache[string, string]()
+	kv := NewKV[string](cache)
+
+	for i := 999; i >= 0; i-- {
+		key := fmt.Sprintf("%03d", i)
+		kv.Set(key, key)
+	}
+
+	expected := []string{
+		"000", "001", "002", "003", "004", "005", "006", "007", "008", "009",
+	}
+
+	got, err := kv.ListByPrefix("00")
+	if err != nil {
+		t.Fatalf("unexpected error in ListByPrefix: %v", err)
+	}
+	compareSlice(t, expected, got)
+
+	expected = []string{
+		"120", "121", "122", "123", "124", "125", "126", "127", "128", "129",
+	}
+
+	got, err = kv.ListByPrefix("12")
+	if err != nil {
+		t.Fatalf("unexpected error in ListByPrefix: %v", err)
+	}
+	compareSlice(t, expected, got)
+
+	expected = []string{"888"}
+
+	got, err = kv.ListByPrefix("888")
+	if err != nil {
+		t.Fatalf("unexpected error in ListByPrefix: %v", err)
+	}
+	compareSlice(t, expected, got)
+
+	kv.Del("777")
+	kv.Del("779")
+
+	if _, err := kv.Get("777"); err != ErrNotFound {
+		t.Fatalf("expected error %v, got %v", ErrNotFound, err)
+	}
+
+	expected = []string{
+		"770", "771", "772", "773", "774", "775", "776", "778",
+	}
+
+	got, err = kv.ListByPrefix("77")
+	if err != nil {
+		t.Fatalf("unexpected error in ListByPrefix: %v", err)
+	}
+
+	kv.Set("777", "777")
+	kv.Set("779", "779")
+
+	compareSlice(t, expected, got)
+
+	expected = []string{
+		"770", "771", "772", "773", "774", "775", "776", "777", "778", "779",
+	}
+
+	got, err = kv.ListByPrefix("77")
+	if err != nil {
+		t.Fatalf("unexpected error in ListByPrefix: %v", err)
+	}
+
+	compareSlice(t, expected, got)
+
+	kv.Set("77", "77")
+
+	expected = []string{
+		"77", "770", "771", "772", "773", "774", "775", "776", "777", "778", "779",
+	}
+
+	got, err = kv.ListByPrefix("77")
+	if err != nil {
+		t.Fatalf("unexpected error in ListByPrefix: %v", err)
+	}
+
+	compareSlice(t, expected, got)
+}
+
+func TestKVEmptyPrefix(t *testing.T) {
+	cache := NewMapCache[string, string]()
+	kv := NewKV[string](cache)
+
+	expected := []string{}
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprintf("%02d", i)
+		expected = append(expected, key)
+		kv.Set(key, key)
+	}
+
+	got, err := kv.ListByPrefix("")
+	if err != nil {
+		t.Fatalf("unexpected error in ListByPrefix: %v", err)
+	}
+	
+	compareSlice(t, expected, got)
+}

--- a/kv_test.go
+++ b/kv_test.go
@@ -57,8 +57,8 @@ func TestKV(t *testing.T) {
 	}
 	compareSlice(t, expected, got)
 
-	kv.Del("777")
-	kv.Del("779")
+	_ = kv.Del("777")
+	_ = kv.Del("779")
 
 	if _, err := kv.Get("777"); err != ErrNotFound {
 		t.Fatalf("expected error %v, got %v", ErrNotFound, err)
@@ -118,6 +118,6 @@ func TestKVEmptyPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error in ListByPrefix: %v", err)
 	}
-	
+
 	compareSlice(t, expected, got)
 }

--- a/kv_test.go
+++ b/kv_test.go
@@ -6,6 +6,20 @@ import (
 	"testing"
 )
 
+func ExampleNewKV() {
+	cache := NewMapCache[string, string]()
+	kv := NewKV[string](cache)
+
+	kv.Set("foo", "bar")
+	kv.Set("foo2", "bar2")
+	kv.Set("foo3", "bar3")
+	kv.Set("foo1", "bar1")
+
+	res, _ := kv.ListByPrefix("foo")
+	fmt.Println(res)
+	// Output: [bar bar1 bar2 bar3]
+}
+
 func compareSlice(t *testing.T, exp, got []string) {
 	t.Helper()
 

--- a/updater_test.go
+++ b/updater_test.go
@@ -1,7 +1,9 @@
 package geche
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"sync"
 	"testing"
@@ -16,6 +18,26 @@ func updateFn(key string) (string, error) {
 
 func updateErrFn(key string) (string, error) {
 	return "", errThe
+}
+
+func ExampleNewCacheUpdater() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a cache updater with updaterFunction
+	// that sets cache value equal to the key.
+	u := NewCacheUpdater[string, string](
+		NewMapTTLCache[string, string](ctx, time.Minute, time.Minute),
+		updateFn,
+		2,
+	)
+
+	// Value is not in the cache yet.
+	// But it will be set by the updater function.
+	v, _ := u.Get("nonexistent")
+	fmt.Println(v)
+
+	// Output: nonexistent
 }
 
 func TestUpdaterScenario(t *testing.T) {


### PR DESCRIPTION
`NewKV` wrapper that adds `ListByPrefix(prefix string) ([]V, error)` function.
It allows to access underlying cache like in memory KV database - using key prefix.
Values are returned in lexicographical order of their keys (as long as keys are ASCII).