### PR TITLE
Feature/ll kv opt

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -131,7 +131,7 @@ func testDelOdd(t *testing.T, imp Geche[string, string]) {
 		}
 
 		if err != ErrNotFound {
-			t.Errorf("expected error %v, got %v", ErrNotFound, err)
+			t.Errorf("expected error %v, got %v and value %q", ErrNotFound, err, val)
 		}
 	}
 

--- a/kv.go
+++ b/kv.go
@@ -5,14 +5,84 @@ import (
 )
 
 type trieNode struct {
-	c    byte
-	next map[byte]*trieNode
-	// min and max are used to speed up the search
-	// without resorting to implementing double linked list.
-	min byte
-	max byte
+	c byte
+
+	// Nodes down the tree are stored in a map.
+	down map[byte]*trieNode
+
+	// Linked list of nodes on the same level.
+	next *trieNode
+	prev *trieNode
+
+	// Fastpath to first node on the next level for DFS.
+	nextLevelHead *trieNode
 
 	terminal bool
+}
+
+// Adds a new node to the linked list and returns the new head (if it has changed).
+// If head did not change, return value will be nil.
+// Should be called on the head node.
+func (n *trieNode) addToList(node *trieNode) *trieNode {
+	curr := n
+	for {
+		if node.c < curr.c {
+			node.prev = curr.prev
+			node.next = curr
+			curr.prev = node
+			if node.prev != nil {
+				node.prev.next = node
+			}
+
+			if curr == n {
+				// Head has changed.
+				return node
+			}
+
+			return nil
+		}
+
+		if curr.next == nil {
+			// Adding to the end of the list.
+			node.prev = curr
+			curr.next = node
+			return nil
+		}
+
+		curr = curr.next
+	}
+}
+
+// Removes node from the linked list.
+// Returns the new head (if it has changed).
+// Should be called on the head node.
+func (n *trieNode) removeFromList(c byte) *trieNode {
+	curr := n
+	for {
+		if curr.c == c {
+			if curr.prev != nil {
+				curr.prev.next = curr.next
+			}
+
+			if curr.next != nil {
+				curr.next.prev = curr.prev
+			}
+
+			if curr.prev == nil {
+				// Head has changed.
+				return curr.next
+			}
+
+			return nil
+		}
+
+		curr = curr.next
+
+		if curr == nil {
+			// Node was not found.
+			return nil
+		}
+	}
 }
 
 type KV[V any] struct {
@@ -26,44 +96,53 @@ func NewKV[V any](
 ) *KV[V] {
 	kv := KV[V]{
 		data: cache,
-		trie: new(trieNode),
+		trie: &trieNode{
+			down: make(map[byte]*trieNode),
+		},
 	}
 
 	return &kv
 }
 
 // Set key-value pair while updating the trie.
+// Panics if key is empty.
 func (kv *KV[V]) Set(key string, value V) {
 	kv.mux.Lock()
 	defer kv.mux.Unlock()
 
 	kv.data.Set(key, value)
 
+	if key == "" {
+		kv.trie.terminal = true
+		return
+	}
+
 	node := kv.trie
-	prev := node
 	for i := 0; i < len(key); i++ {
-		if node.next == nil {
-			node.next = make(map[byte]*trieNode)
-			node.min = key[i]
-			node.max = key[i]
+		if node.down == nil {
+			// Creating new level.
+			node.down = make(map[byte]*trieNode)
 		}
 
-		if key[i] < node.min {
-			node.min = key[i]
-		}
-		if key[i] > node.max {
-			node.max = key[i]
-		}
-
-		node = node.next[key[i]]
-		if node == nil {
-			node = &trieNode{
+		next := node.down[key[i]]
+		if next == nil {
+			// Creating new node.
+			next = &trieNode{
 				c: key[i],
 			}
-			prev.next[key[i]] = node
+			node.down[key[i]] = next
+			if node.nextLevelHead == nil {
+				node.nextLevelHead = next
+			} else {
+				// Adding node to the linked list.
+				head := node.nextLevelHead.addToList(next)
+				if head != nil {
+					node.nextLevelHead = head
+				}
+			}
 		}
 
-		prev = node
+		node = next
 	}
 
 	node.terminal = true
@@ -72,16 +151,13 @@ func (kv *KV[V]) Set(key string, value V) {
 type stackItem[V any] struct {
 	node   *trieNode
 	prefix []byte
-	c      byte
 }
 
+// DFS starts with last node of the key prefix.
 func (kv *KV[V]) dfs(node *trieNode, prefix []byte) ([]V, error) {
 	res := []V{}
 
-	stack := []stackItem[V]{
-		{node: node, c: node.min},
-	}
-
+	// If last node of the prefix is terminal, add it to the result.
 	if node.terminal {
 		val, err := kv.data.Get(string(prefix))
 		if err != nil {
@@ -90,10 +166,14 @@ func (kv *KV[V]) dfs(node *trieNode, prefix []byte) ([]V, error) {
 		res = append(res, val)
 	}
 
-	var (
-		top  stackItem[V]
-		next *trieNode
-	)
+	// If the node does not contain any descendants, return.
+	if node.nextLevelHead == nil {
+		return res, nil
+	}
+
+	stack := make([]stackItem[V], 0, 1024)
+	stack = append(stack, stackItem[V]{node: node.nextLevelHead})
+	var top stackItem[V]
 	for {
 		if len(stack) == 0 {
 			break
@@ -102,21 +182,26 @@ func (kv *KV[V]) dfs(node *trieNode, prefix []byte) ([]V, error) {
 		top = stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
 
-		if top.c < top.node.max {
-			stack = append(stack, stackItem[V]{node: top.node, prefix: top.prefix, c: top.c + 1})
+		if top.node.terminal {
+			key := append(prefix, top.prefix...)
+			val, err := kv.data.Get(string(append(key, top.node.c)))
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, val)
 		}
 
-		if top.node.next[top.c] != nil {
-			next = top.node.next[top.c]
-			if next.terminal {
-				key := append(prefix, top.prefix...)
-				val, err := kv.data.Get(string(append(key, top.c)))
-				if err != nil {
-					return nil, err
-				}
-				res = append(res, val)
-			}
-			stack = append(stack, stackItem[V]{node: next, prefix: append(top.prefix, top.c), c: top.node.min})
+		// Appending next node of the level to the stack.
+		if top.node.next != nil {
+			stack = append(stack, stackItem[V]{node: top.node.next, prefix: top.prefix})
+		}
+
+		// Appending next level head to the top of the stack.
+		if top.node.nextLevelHead != nil {
+			stack = append(stack, stackItem[V]{
+				node:   top.node.nextLevelHead,
+				prefix: append(top.prefix, top.node.c),
+			})
 		}
 	}
 
@@ -129,7 +214,7 @@ func (kv *KV[V]) ListByPrefix(prefix string) ([]V, error) {
 
 	node := kv.trie
 	for i := 0; i < len(prefix); i++ {
-		next := node.next[prefix[i]]
+		next := node.down[prefix[i]]
 		if next == nil {
 			return nil, nil
 		}
@@ -152,7 +237,7 @@ func (kv *KV[V]) Del(key string) error {
 	node := kv.trie
 	var prev *trieNode
 	for i := 0; i < len(key); i++ {
-		next := node.next[key[i]]
+		next := node.down[key[i]]
 		if next == nil {
 			return nil
 		}
@@ -163,22 +248,9 @@ func (kv *KV[V]) Del(key string) error {
 
 	node.terminal = false
 
-	empty := true
-	i := byte(0)
-	for {
-		if node.next[i] != nil {
-			empty = false
-			break
-		}
-
-		if i == 255 {
-			break
-		}
-		i++
-	}
-
-	if empty {
-		prev.next[node.c] = nil
+	if node.next == nil {
+		prev.removeFromList(node.c)
+		prev.down[node.c] = nil
 	}
 
 	return kv.data.Del(key)

--- a/kv.go
+++ b/kv.go
@@ -6,7 +6,7 @@ import (
 
 // Length of key to preallocate in dfs.
 // It is not a hard limit, but keys longer than this will cause extra allocations.
-const maxKeyLength = 1024
+const maxKeyLength = 512
 
 type trieNode struct {
 	// character
@@ -172,7 +172,7 @@ func (kv *KV[V]) dfs(node *trieNode, prefix []byte) ([]V, error) {
 		return res, nil
 	}
 
-	stack := make([]*trieNode, 0, 1024)
+	stack := make([]*trieNode, 0, maxKeyLength)
 	stack = append(stack, node.nextLevelHead)
 	var (
 		top       *trieNode

--- a/kv.go
+++ b/kv.go
@@ -56,6 +56,7 @@ func (n *trieNode) addToList(node *trieNode) *trieNode {
 // Removes node from the linked list.
 // Returns the new head (if it has changed).
 // Should be called on the head node.
+// Will loop forever if node is not in the list.
 func (n *trieNode) removeFromList(c byte) *trieNode {
 	curr := n
 	for {
@@ -77,11 +78,6 @@ func (n *trieNode) removeFromList(c byte) *trieNode {
 		}
 
 		curr = curr.next
-
-		if curr == nil {
-			// Node was not found.
-			return nil
-		}
 	}
 }
 
@@ -248,9 +244,12 @@ func (kv *KV[V]) Del(key string) error {
 
 	node.terminal = false
 
-	if node.next == nil {
-		prev.removeFromList(node.c)
-		prev.down[node.c] = nil
+	if node.nextLevelHead == nil && prev != nil {
+		head := prev.nextLevelHead.removeFromList(node.c)
+		if head != nil {
+			prev.nextLevelHead = head
+		}
+		delete(prev.down, node.c)
 	}
 
 	return kv.data.Del(key)

--- a/kv_test.go
+++ b/kv_test.go
@@ -151,6 +151,28 @@ func TestKVNonexist(t *testing.T) {
 	if len(got) > 0 {
 		t.Errorf("unexpected len %d", len(got))
 	}
+
+	if err := kv.Del("nonexistent"); err != nil {
+		t.Errorf("unexpected error in Del: %v", err)
+	}
+}
+
+func TestKVEmptyKEy(t *testing.T) {
+	cache := NewMapCache[string, string]()
+	kv := NewKV[string](cache)
+
+	kv.Set("", "0")
+	kv.Set("foo1", "1")
+	kv.Set("foo2", "2")
+
+	got, err := kv.ListByPrefix("fo")
+	if err != nil {
+		t.Fatalf("unexpected error in ListByPrefix: %v", err)
+	}
+
+	if len(got) > 3 {
+		t.Errorf("unexpected len %d", len(got))
+	}
 }
 
 func TestKVError(t *testing.T) {

--- a/kv_test.go
+++ b/kv_test.go
@@ -30,7 +30,7 @@ func compareSlice(t *testing.T, exp, got []string) {
 
 	for i := 0; i < len(exp); i++ {
 		if exp[i] != got[i] {
-			t.Errorf("expected %q, got %q", exp[i], got[i])
+			t.Errorf("%d: expected %q, got %q", i, exp[i], got[i])
 		}
 	}
 }


### PR DESCRIPTION
Couple of optimizations leading to 2500x speedup.
Before:
```
BenchmarkKVListByPrefix-8            463           8145020 ns/op
```
After:
```
BenchmarkKVListByPrefix-8         467209              3159 ns/op
```

1. Use linked list for faster iteration in DFS.
2. Use (and reuse) preallocated byte slice for current node key, instead of keeping prefixes in the stack.
3. Stack 100% preallocated now