### PR TITLE
Locker wrapper for atomic cache operations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         go-version: "1.20"
 
     - name: Test
-      run: go test -v -bench . -covermode=atomic -coverprofile=coverage.out -race ./...
+      run: go test -v -covermode=atomic -coverprofile=coverage.out -race ./...
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ Be careful to follow these rules (will lead to panics):
 * do not `Unlock` `Tx` that was unlocked before.
 And do not forget to `Unlock` the `Tx` object, otherwise it will lead to lock to be held forever.
 
+Returned `Tx` object is not a transaction in a sense that it does not
+allow commit/rollback or isolation level higher than READ COMMITTED.
+It only provides a way to do multiple cache operations atomically.
+
 ## Benchmarks
 
 Test suite contains a couple of benchmarks to compare the speed difference between old-school generic implementation using `interface{}` or `any` to hold cache values versus using generics.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ if err != nil {
 fmt.Println(v)
 ```
 
+`Updater` provides `ListByPrefix` function, but it can be used only if underlying cache supports it (is a `KV` wrapper).
+Otherwize it will panic.
+
 ### Sharding
 
 If you intend to use cache in *higlhy* concurrent manner (16+ cores and 100k+ RPS). It may make sense to shard it.
@@ -140,7 +143,7 @@ Internally `KV` maintains trie structure to store keys to be able to quickly fin
 This wrapper has some limitations:
 * `KV` only supports keys of type `string`.
 * Lexicographical order is maintained on the byte level, so it will work as expected for ASCII strings, but may not work for other encodings.
-* If you wrap `KV` with another wrapper you can't use `ListByPrefix`. Don't do it!
+* `Updater` and `Locker` wrappers provide `ListByPrefix` function, that will call underlying `KV` implementation. But if you wrap `KV` with `Sharded` wrapper, you will loose this functionality. In other words it would not make sense to wrap `KV` with `Sharded` wrapper.
 
 ```go
 	cache := NewMapCache[string, string]()
@@ -188,8 +191,9 @@ Be careful to follow these rules (will lead to panics):
 And do not forget to `Unlock` the `Tx` object, otherwise it will lead to lock to be held forever.
 
 Returned `Tx` object is not a transaction in a sense that it does not
-allow commit/rollback or isolation level higher than READ COMMITTED.
-It only provides a way to do multiple cache operations atomically.
+allow rollback, but it provides atomicity and isolation guarantees.
+
+`Locker` provides `ListByPrefix` function, but it can only be used if underlying cache implementation supports it (is a `KV` wrapper). Otherwize it will panic.
 
 ## Benchmarks
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -158,6 +158,10 @@ func BenchmarkEverything(b *testing.B) {
 			"KVMapCache",
 			NewKV[string](NewMapCache[string, string]()),
 		},
+		{
+			"LockerMapCache",
+			NewLocker[string, string](NewMapCache[string, string]()).Lock(),
+		},
 	}
 
 	data := genTestData(10_000_000)

--- a/common_test.go
+++ b/common_test.go
@@ -159,6 +159,9 @@ func TestCommon(t *testing.T) {
 		{"MapTTLCache", func() Geche[string, string] { return NewMapTTLCache[string, string](ctx, time.Minute, time.Minute) }},
 		{"RingBuffer", func() Geche[string, string] { return NewRingBuffer[string, string](100) }},
 		{"KVMapCache", func() Geche[string, string] { return NewKV[string](NewMapCache[string, string]()) }},
+		{"LockerMapCache", func() Geche[string, string] {
+			return NewLocker[string, string](NewMapCache[string, string]()).Lock()
+		}},
 		{
 			"ShardedMapCache", func() Geche[string, string] {
 				return NewSharded[string](

--- a/locker.go
+++ b/locker.go
@@ -9,7 +9,7 @@ import (
 // that provides Lock() and RLock() methods that return Tx object
 // implementing Geche interface.
 // Returned object is not a transaction in a sense that it does not
-// allow commit/rollback or isolation level higher than READ UNCOMMITTED.
+// allow commit/rollback or isolation level higher than READ COMMITTED.
 // It only provides a way to do multiple cache operations atomically.
 type Locker[K comparable, V any] struct {
 	cache Geche[K, V]

--- a/locker.go
+++ b/locker.go
@@ -117,3 +117,17 @@ func (tx *Tx[K, V]) Len() int {
 	}
 	return tx.cache.Len()
 }
+
+// ListByPrefix should only be called if underlying cache is KV.
+// Otherwise it will panic.
+func (tx *Tx[K, V]) ListByPrefix(prefix string) ([]V, error) {
+	if atomic.LoadInt32(&tx.unlocked) == 1 {
+		panic("cannot use unlocked transaction")
+	}
+	kv, ok := any(tx.cache).(*KV[V])
+	if !ok {
+		panic("cache does not support ListByPrefix")
+	}
+
+	return kv.ListByPrefix(prefix)
+}

--- a/locker.go
+++ b/locker.go
@@ -1,0 +1,119 @@
+package geche
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Locker is a wrapper for any Geche interface implementation,
+// that provides Lock() and RLock() methods that return Tx object
+// implementing Geche interface.
+// Returned object is not a transaction in a sense that it does not
+// allow commit/rollback or isolation level higher than READ UNCOMMITTED.
+// It only provides a way to do multiple cache operations atomically.
+type Locker[K comparable, V any] struct {
+	cache Geche[K, V]
+	mux   *sync.RWMutex
+}
+
+// NewLocker creates a new Locker instance.
+func NewLocker[K comparable, V any](
+	cache Geche[K, V],
+) *Locker[K, V] {
+	t := Locker[K, V]{
+		cache: cache,
+		mux:   &sync.RWMutex{},
+	}
+
+	return &t
+}
+
+// Tx is a "transaction" object returned by Locker.Lock() and Locker.RLock() methods.
+// See Locker for more details.
+type Tx[K comparable, V any] struct {
+	cache    Geche[K, V]
+	mux      *sync.RWMutex
+	writable bool
+	unlocked int32
+}
+
+// Retuns read/write locked cache object.
+func (t *Locker[K, V]) Lock() *Tx[K, V] {
+	t.mux.Lock()
+	return &Tx[K, V]{
+		cache:    t.cache,
+		mux:      t.mux,
+		writable: true,
+	}
+}
+
+// Retuns read-only locked cache object.
+func (t *Locker[K, V]) RLock() *Tx[K, V] {
+	t.mux.RLock()
+	return &Tx[K, V]{
+		cache:    t.cache,
+		mux:      t.mux,
+		writable: false,
+	}
+}
+
+// Unlock underlying cache.
+func (tx *Tx[K, V]) Unlock() {
+	if atomic.LoadInt32(&tx.unlocked) == 1 {
+		panic("unlocking already unlocked transaction")
+	}
+	atomic.StoreInt32(&tx.unlocked, 1)
+	if tx.writable {
+		tx.mux.Unlock()
+		return
+	}
+	tx.mux.RUnlock()
+}
+
+// Set key-value pair in the underlying locked cache.
+// Will panic if called on RLocked Tx.
+func (tx *Tx[K, V]) Set(key K, value V) {
+	if atomic.LoadInt32(&tx.unlocked) == 1 {
+		panic("cannot use unlocked transaction")
+	}
+	if !tx.writable {
+		panic("cannot set in read-only transaction")
+	}
+	tx.cache.Set(key, value)
+}
+
+// Get value by key from the underlying sharded cache.
+func (tx *Tx[K, V]) Get(key K) (V, error) {
+	if atomic.LoadInt32(&tx.unlocked) == 1 {
+		panic("cannot use unlocked transaction")
+	}
+	return tx.cache.Get(key)
+}
+
+// Del key from the underlying locked cache.
+// Will panic if called on RLocked Tx.
+func (tx *Tx[K, V]) Del(key K) error {
+	if atomic.LoadInt32(&tx.unlocked) == 1 {
+		panic("cannot use unlocked transaction")
+	}
+	if !tx.writable {
+		panic("cannot del in read-only transaction")
+	}
+	return tx.cache.Del(key)
+}
+
+// Snapshot returns a shallow copy of the cache data.
+func (tx *Tx[K, V]) Snapshot() map[K]V {
+	if atomic.LoadInt32(&tx.unlocked) == 1 {
+		panic("cannot use unlocked transaction")
+	}
+	return tx.cache.Snapshot()
+}
+
+// Len returns total number of elements in the cache.
+func (tx *Tx[K, V]) Len() int {
+	if atomic.LoadInt32(&tx.unlocked) == 1 {
+		panic("cannot use unlocked transaction")
+	}
+	return tx.cache.Len()
+}

--- a/locker_test.go
+++ b/locker_test.go
@@ -1,0 +1,149 @@
+package geche
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+)
+
+func TestLockerParallel(t *testing.T) {
+	// Use locker to simulate atomic balance transfer between accounts.
+	// Single transfer consists of getting balance of two accounts,
+	// then subtracting some amount from one and adding it to another.
+	// Operation is run concurrently on multiple goroutines,
+	// If tx isolation is not implemented correctly total balance can change.
+	locker := NewLocker[int, int](NewMapCache[int, int]())
+
+	numAccounts := 10
+	numTransactions := 100000
+	initialBalance := 1000
+
+	tx := locker.Lock()
+	for i := 0; i < numAccounts; i++ {
+		tx.Set(i, initialBalance)
+	}
+	tx.Unlock()
+	totalBalance := numAccounts * initialBalance
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < numTransactions; i++ {
+		wg.Add(1)
+		go func() {
+			accA := rand.Intn(numAccounts)
+			var accB int
+			for accB = rand.Intn(numAccounts); accB == accA; accB = rand.Intn(numAccounts) {
+			}
+			tx := locker.Lock()
+			balA, _ := tx.Get(accA)
+			balB, _ := tx.Get(accB)
+
+			if balA < balB {
+				size := rand.Intn(balB)
+				balA += size
+				balB -= size
+				tx.Set(accA, balA)
+				tx.Set(accB, balB)
+			} else {
+				size := rand.Intn(balA)
+				balB += size
+				balA -= size
+				tx.Set(accA, balA)
+				tx.Set(accB, balB)
+			}
+
+			tx.Unlock()
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	tx = locker.RLock()
+	sum := 0
+	for i := 0; i < numAccounts; i++ {
+		bal, _ := tx.Get(i)
+		sum += bal
+	}
+	tx.Unlock()
+
+	if sum != totalBalance {
+		t.Errorf("expected %d, got %d", totalBalance, sum)
+	}
+}
+
+func panics(f func()) (panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+		}
+	}()
+
+	f()
+	return
+}
+
+func TestLockerRPanics(t *testing.T) {
+	locker := NewLocker[int, int](NewMapCache[int, int]())
+	tx := locker.RLock()
+	if !panics(func() { tx.Set(1, 1) }) {
+		t.Errorf("expected panic (Set on RLocked)")
+	}
+
+	if !panics(func() { tx.Del(1) }) {
+		t.Errorf("expected panic (Delete on RLocked)")
+	}
+
+	tx.Unlock()
+	if !panics(func() { tx.Unlock() }) {
+		t.Errorf("expected panic (Unlock on already unlocked)")
+	}
+
+	if !panics(func() { tx.Set(1, 1) }) {
+		t.Errorf("expected panic (Set on already unlocked)")
+	}
+
+	if !panics(func() { tx.Del(1) }) {
+		t.Errorf("expected panic (Delete on already unlocked)")
+	}
+
+	if !panics(func() { tx.Get(1) }) {
+		t.Errorf("expected panic (Get on already unlocked)")
+	}
+
+	if !panics(func() { tx.Len() }) {
+		t.Errorf("expected panic (Len on already unlocked)")
+	}
+
+	if !panics(func() { tx.Snapshot() }) {
+		t.Errorf("expected panic (Snapshot on already unlocked)")
+	}
+}
+
+func TestLockerRWPanics(t *testing.T) {
+	locker := NewLocker[int, int](NewMapCache[int, int]())
+	tx := locker.Lock()
+
+	tx.Unlock()
+	if !panics(func() { tx.Unlock() }) {
+		t.Errorf("expected panic (Unlock on already unlocked)")
+	}
+
+	if !panics(func() { tx.Set(1, 1) }) {
+		t.Errorf("expected panic (Set on already unlocked)")
+	}
+
+	if !panics(func() { tx.Del(1) }) {
+		t.Errorf("expected panic (Delete on already unlocked)")
+	}
+
+	if !panics(func() { tx.Get(1) }) {
+		t.Errorf("expected panic (Get on already unlocked)")
+	}
+
+	if !panics(func() { tx.Len() }) {
+		t.Errorf("expected panic (Len on already unlocked)")
+	}
+
+	if !panics(func() { tx.Snapshot() }) {
+		t.Errorf("expected panic (Snapshot on already unlocked)")
+	}
+}

--- a/locker_test.go
+++ b/locker_test.go
@@ -123,7 +123,7 @@ func TestLockerRWPanics(t *testing.T) {
 	locker := NewLocker[int, int](NewMapCache[int, int]())
 	tx := locker.Lock()
 
-	if !panics(func() { tx.ListByPrefix("test") }) {
+	if !panics(func() { _, _ = tx.ListByPrefix("test") }) {
 		t.Errorf("expected panic (ListByPrefix on MapCache)")
 	}
 
@@ -152,7 +152,7 @@ func TestLockerRWPanics(t *testing.T) {
 		t.Errorf("expected panic (Snapshot on already unlocked)")
 	}
 
-	if !panics(func() { tx.ListByPrefix("test") }) {
+	if !panics(func() { _, _ = tx.ListByPrefix("test") }) {
 		t.Errorf("expected panic (ListByPrefix on already unlocked)")
 	}
 }
@@ -167,7 +167,7 @@ func TestLockerListByPrefix(t *testing.T) {
 	tx.Set("test1", "test1")
 	tx.Set("test3", "test3")
 
-	tx.Del("test2")
+	_ = tx.Del("test2")
 
 	expected := []string{"test1", "test3", "test9"}
 	actual, err := tx.ListByPrefix("test")

--- a/locker_test.go
+++ b/locker_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package geche
 
 import (

--- a/updater.go
+++ b/updater.go
@@ -117,3 +117,14 @@ func (u *Updater[K, V]) Snapshot() map[K]V {
 func (u *Updater[K, V]) Len() int {
 	return u.cache.Len()
 }
+
+// ListByPrefix should only be called if underlying cache is KV.
+// Otherwise it will panic.
+func (u *Updater[K, V]) ListByPrefix(prefix string) ([]V, error) {
+	kv, ok := any(u.cache).(*KV[V])
+	if !ok {
+		panic("cache does not support ListByPrefix")
+	}
+
+	return kv.ListByPrefix(prefix)
+}

--- a/updater_test.go
+++ b/updater_test.go
@@ -224,7 +224,7 @@ func TestUpdaterListByPrefix(t *testing.T) {
 	imp.Set("test1", "test1")
 	imp.Set("test3", "test3")
 
-	imp.Del("test2")
+	_ = imp.Del("test2")
 
 	expected := []string{"test1", "test3", "test9"}
 	actual, err := imp.ListByPrefix("test")
@@ -238,7 +238,7 @@ func TestUpdaterListByPrefix(t *testing.T) {
 func TestUpdaterListByPrefixUnsupported(t *testing.T) {
 	imp := NewCacheUpdater[string, string](NewMapCache[string, string](), updateFn, 2)
 
-	if !panics(func() { imp.ListByPrefix("test") }) {
+	if !panics(func() { _, _ = imp.ListByPrefix("test") }) {
 		t.Error("ListByPrefix expected to panic if underlying cache does not provide ListByPrefix")
 	}
 }

--- a/updater_test.go
+++ b/updater_test.go
@@ -215,3 +215,30 @@ func TestUpdaterConcurrent(t *testing.T) {
 		t.Errorf("expected peakCnt to be %d, got %d", poolSize, peakCnt)
 	}
 }
+
+func TestUpdaterListByPrefix(t *testing.T) {
+	imp := NewCacheUpdater[string, string](NewKV[string](NewMapCache[string, string]()), updateFn, 2)
+
+	imp.Set("test9", "test9")
+	imp.Set("test2", "test2")
+	imp.Set("test1", "test1")
+	imp.Set("test3", "test3")
+
+	imp.Del("test2")
+
+	expected := []string{"test1", "test3", "test9"}
+	actual, err := imp.ListByPrefix("test")
+	if err != nil {
+		t.Errorf("unexpected error in ListByPrefix: %v", err)
+	}
+
+	compareSlice(t, expected, actual)
+}
+
+func TestUpdaterListByPrefixUnsupported(t *testing.T) {
+	imp := NewCacheUpdater[string, string](NewMapCache[string, string](), updateFn, 2)
+
+	if !panics(func() { imp.ListByPrefix("test") }) {
+		t.Error("ListByPrefix expected to panic if underlying cache does not provide ListByPrefix")
+	}
+}


### PR DESCRIPTION
Added new `Locker` wrapper, that allows to do atomic operations on the cache (e.g. update several values without possibility of race condition when one of the values was updated, but second is not yet).