### PR TITLE
fix error when DFS failed to backtrack on trie depth jump > 1

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -193,7 +193,7 @@ func (kv *KV[V]) dfs(node *trieNode, prefix []byte) ([]V, error) {
 			key = append(key, top.c)
 		} else if top.d < prevDepth {
 			// We have ascended to the previous level.
-			key = key[:len(key)-1]
+			key = key[:len(key)-(prevDepth-top.d)]
 			key[len(key)-1] = top.c
 		} else {
 			key[len(key)-1] = top.c


### PR DESCRIPTION
ListByPrefix failed to return results when there was a DFS trie depth jump of more than 1 level.
E.g. for keys "123" and "3", DFS would descend to level 3, and then it should go back to level 1, but it did not do it correctly.