### PR TITLE
KV key tail optimization

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -203,7 +203,7 @@ func BenchmarkKVListByPrefix(b *testing.B) {
 	c := NewKV[string](NewMapCache[string, string]())
 	keys := make([]string, 100_000)
 	for i := 0; i < 100_000; i++ {
-		l := rand.Intn(36)
+		l := rand.Intn(15)+15
 		unique := randomString(l)
 		keys[i] = unique
 		for j := 0; j < 10; j++ {
@@ -213,6 +213,12 @@ func BenchmarkKVListByPrefix(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = c.ListByPrefix(keys[i%len(keys)])
+		res, err := c.ListByPrefix(keys[i%len(keys)])
+		if err != nil {
+			b.Errorf("unexpected error in ListByPrefix: %v", err)
+		}
+		if len(res) != 10 {
+			b.Errorf("expected len 10, but got %d", len(res))
+		}
 	}
 }

--- a/kv.go
+++ b/kv.go
@@ -360,6 +360,7 @@ func (kv *KV[V]) Del(key string) error {
 
 	node := kv.trie
 	stack := []*trieNode{}
+	found := false
 	for i := 0; i < len(key); i++ {
 		next := node.down[key[i]]
 		if next == nil {
@@ -370,10 +371,18 @@ func (kv *KV[V]) Del(key string) error {
 		stack = append(stack, node)
 		node = next
 		if bytes.Equal(node.b, []byte(key)[i:]) {
+			if node.terminal {
+				found = true
+			}
 			break
 		}
 	}
 
+	if !found {
+		// If we are here, the key does not exist.
+		return kv.data.Del(key)
+	}
+	
 	node.terminal = false
 
 	// Go back the stack removing nodes with no descendants.

--- a/kv.go
+++ b/kv.go
@@ -334,7 +334,7 @@ func (kv *KV[V]) ListByPrefix(prefix string) ([]V, error) {
 		if next == nil {
 			return nil, nil
 		}
-		if bytes.Equal(next.b, []byte(prefix)[i:]) {
+		if bytes.Equal(next.b[:len(prefix)-i], []byte(prefix)[i:]) {
 			return kv.dfs(next, []byte(prefix))
 		}
 		node = next

--- a/kv.go
+++ b/kv.go
@@ -334,8 +334,13 @@ func (kv *KV[V]) ListByPrefix(prefix string) ([]V, error) {
 		if next == nil {
 			return nil, nil
 		}
-		if bytes.Equal(next.b[:len(prefix)-i], []byte(prefix)[i:]) {
-			return kv.dfs(next, []byte(prefix))
+		// If we reached a multibyte tail node, we can return its value,
+		// since tail nodes have no descendants.
+		if len(next.b) > 1 && len(next.b) >= len(prefix)-i {
+			if bytes.Equal(next.b[:len(prefix)-i], []byte(prefix)[i:]) {
+				v, err := kv.data.Get(prefix + string(next.b[len(prefix)-i:]))
+				return []V{v}, err
+			}
 		}
 		node = next
 	}

--- a/kv_test.go
+++ b/kv_test.go
@@ -317,6 +317,19 @@ func TestKVError(t *testing.T) {
 	}
 }
 
+func TestKVListByPrefix2Error(t *testing.T) {
+	cache := &MockErrCache{}
+	kv := NewKV[string](cache)
+
+	kv.Set("e", "wat")
+	kv.Set("er", "wat")
+	kv.Set("err", "something")
+	_, err := kv.ListByPrefix("err")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
 // To check that the error is propagated correctly.
 type MockErrCache struct{}
 
@@ -747,7 +760,7 @@ func FuzzKVSetListByPrefix(f *testing.F) {
 func TestKVDelNoprefix(t *testing.T) {
 	kv := NewKV[string](NewMapCache[string, string]())
 	kv.Set("hu", "hu")
-	kv.Del("h")
+	_ = kv.Del("h")
 	res, err := kv.Get("hu")
 	if err != nil {
 		t.Errorf("unexpected error in Get: %v", err)
@@ -797,7 +810,8 @@ func FuzzMonkey(f *testing.F) {
 				kv.Set(cmd.key, cmd.key)
 				golden[cmd.key] = struct{}{}
 			} else if cmd.action == "Del" {
-				kv.Del(cmd.key)
+				// Since keys are random we expect a lot of Del to fail.
+				_ = kv.Del(cmd.key)
 				delete(golden, cmd.key)
 			}
 		}

--- a/kv_test.go
+++ b/kv_test.go
@@ -28,7 +28,7 @@ func ExampleNewKV() {
 func compareSlice(t *testing.T, exp, got []string) {
 	t.Helper()
 
-	// t.Log(got)
+	t.Log(got)
 	if len(exp) != len(got) {
 		t.Fatalf("expected length %d, got %d", len(exp), len(got))
 	}
@@ -46,6 +46,9 @@ func TestKV(t *testing.T) {
 
 	for i := 999; i >= 0; i-- {
 		key := fmt.Sprintf("%03d", i)
+		if key == "008" {
+			kv.Set(key, key)
+		}
 		kv.Set(key, key)
 	}
 
@@ -338,7 +341,7 @@ func TestKVAlloc(t *testing.T) {
 	runtime.GC()
 	runtime.ReadMemStats(&mBefore)
 
-	for i := 0; i < 100000; i++ {
+	for i := 0; i < 10000; i++ {
 		key := genRandomString(rand.Intn(300) + 1)
 		rawDataLen += int64(len(key) * 2)
 		kv.Set(key, key)

--- a/tails.md
+++ b/tails.md
@@ -1,0 +1,53 @@
+# Tail aggregation storage optimization
+
+Instead of storing each character of the trie in the separate node, we can store a "tail" string in the stingle node. This will reduce the number of nodes in the trie and will reduce the memory consumption.
+
+"Tail" is the suffix part of the key that belongs to one key only.
+
+For example before optimiztion keys "apple" and "approve" will be stored this way (one node per character):
+
+a - p - p - l - e
+        |
+        r - o - v - e
+
+After "tail aggregation" the suffix parts of both keys can be aggregated in the single node:
+
+a - p - p - le
+        |
+        rove
+
+In the first case we have 9 nodes, in the second case we have 5 nodes. Since the node is a rather large structure with several pointers, reducing number of the nodes can significantly reduce memory consumption.
+
+
+## Implementation
+
+### Adding the new key
+
+When adding the new key we should do the same loop over key characters finding corresponding nodes in the existing trie. There are two cases:
+
+1. We reach the end of the key string.
+2. We reach the key character that does not have corresponding trie node.
+
+In first case we keep the current behaviour: just setting "terminal" flag in the last node of the key.
+In the second case instead of adding the "tail" of the key as new nodes one character at a time we add the "tail" as a single node containing the whole tail string insteead of a single character, and setting this node's terminal flag to true.
+
+Oopps. Now we have a third case: while looking for the next character of the key we can reach the node that already has the tail string.
+In this case the easiest option is to delete tail node (but remember the tail string first) and start moving on both strings (key and tail) and adding new nodes until we reach end of one or both strings.
+
+If we reached the end of both strings at the same time this means it is the same key, we just need to update the value. We can optimize this case by comparing tail and remainder of the key. If they are equal, no need to split nodes - just update the value.
+
+If one of the strings is longer than the other, once we reach the shorter string's key we set the terminal flag and new node with the rest of the longer string as a tail.
+
+### Deleting the key
+
+When deleting the key first we do loop over key characters finding corresponding nodes in the existing trie until we reach the end of the key. It should be a terminal node.
+
+If this node has descendants, we just set the terminal flag to false and return.
+
+If it does not have descendants, we need to delete the node and all its ancestors that do not have descendants. We can do it by traversing the trie from the end of the key to the root and deleting all nodes that do not have descendants. The logic here does not change much compared with the case when nodes are single-character. "Tail" node containing string can only be in the end by definition, and in this implementation it can't have descendants.
+
+### Listing by prefix
+
+Listing by prefix should not change much. If we encounter tail node after we exhausted prefix string - we emit this key's value as a part of the result stet, and move along.
+
+If we encounter tail node before we exhausted prefix string - we need to compare prefix string with the tail string. If remaining part of the prefix is the tail's prefix, we add this key's value to the result set and move along. If it is not, just continue our loop as usual.

--- a/tails.md
+++ b/tails.md
@@ -4,7 +4,7 @@ Instead of storing each character of the trie in the separate node, we can store
 
 "Tail" is the suffix part of the key that belongs to one key only.
 
-For example before optimiztion keys "apple" and "approve" will be stored this way (one node per character):
+For example before optimiztion keys "apple" and "approve" were stored this way (one node per character):
 
 a - p - p - l - e
         |


### PR DESCRIPTION
To optimize KV memory usage and lookup time this PR allows leaf trie nodes to represent several symbols.

For example before optimiztion keys "apple" and "approve" were stored this way (one node per character):

```
a - p - p - l - e
        |
        r - o - v - e
```

After "tail aggregation" the suffix parts of both keys can be aggregated in the single node:

```
a - p - p - le
        |
        rove
```
Rationale is explained at length in [tails.md](tails.md).