### PR TITLE
feat: implement SetIfPresent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-.idea/.gitignore
-.idea/geche.iml
-.idea/material_theme_project_new.xml
-.idea/modules.xml
-.idea/vcs.xml
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/.gitignore
+.idea/geche.iml
+.idea/material_theme_project_new.xml
+.idea/modules.xml
+.idea/vcs.xml

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Implementations are as simple as possible to be predictable in max latency, memo
 
 ## Examples
 
-Interface is quite simple with five methods: `Set`, `Get`, `Del`, `Snapshot` and `Len`. Here's a quick example for a ring buffer holding 10k records.
+Interface is quite simple with six methods: `Set`, `Get`, `Del`, `SetIfPresent`, `Snapshot` and `Len`. Here's a quick example for a ring buffer holding 10k records.
 
 ```go
 package main
@@ -37,7 +37,13 @@ func main() {
         fmt.Println(err)
         return
     }
+	
+	// will update the value associated to key 1
+	c.SetIfPresent(1, "two")
+	// will not have any effect
+	c.SetIfPresent(2, "dua")
 
+	// will print 2
     fmt.Println(v)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ func main() {
     }
 	
 	// will update the value associated to key 1
-	c.SetIfPresent(1, "two")
+	previousVal, updated := c.SetIfPresent(1, "two")
+	// will print "one"
+	fmt.Println(previousVal)
+	// will print "true"
+	fmt.Println(updated)
+	
 	// will not have any effect
 	c.SetIfPresent(2, "dua")
 

--- a/common_test.go
+++ b/common_test.go
@@ -37,7 +37,7 @@ func testSetThenSetIfPresentThenGet(t *testing.T, imp Geche[string, string]) {
 
 func testSetIfPresentThenGet(t *testing.T, imp Geche[string, string]) {
 	if imp.SetIfPresent("key", "value") {
-		t.Errorf("expected SetIfPresent to not a new value for non-existing key")
+		t.Errorf("expected SetIfPresent to not insert a new value for non-existing key")
 	}
 
 	val, err := imp.Get("key")

--- a/common_test.go
+++ b/common_test.go
@@ -21,8 +21,13 @@ func testSetGet(t *testing.T, imp Geche[string, string]) {
 
 func testSetThenSetIfPresentThenGet(t *testing.T, imp Geche[string, string]) {
 	imp.Set("key", "value")
-	if !imp.SetIfPresent("key", "value2") {
+	old, inserted := imp.SetIfPresent("key", "value2")
+	if !inserted {
 		t.Errorf("expected SetIfPresent to insert a new value for existing key")
+	}
+
+	if old != "value" {
+		t.Errorf("expected old value %q to be returned from SetIfPresent, got %q", "value", old)
 	}
 
 	val, err := imp.Get("key")
@@ -36,7 +41,7 @@ func testSetThenSetIfPresentThenGet(t *testing.T, imp Geche[string, string]) {
 }
 
 func testSetIfPresentThenGet(t *testing.T, imp Geche[string, string]) {
-	if imp.SetIfPresent("key", "value") {
+	if _, inserted := imp.SetIfPresent("key", "value"); inserted {
 		t.Errorf("expected SetIfPresent to not insert a new value for non-existing key")
 	}
 

--- a/common_test.go
+++ b/common_test.go
@@ -19,6 +19,33 @@ func testSetGet(t *testing.T, imp Geche[string, string]) {
 	}
 }
 
+func testSetThenSetIfPresentThenGet(t *testing.T, imp Geche[string, string]) {
+	imp.Set("key", "value")
+	if !imp.SetIfPresent("key", "value2") {
+		t.Errorf("expected SetIfPresent to insert a new value for existing key")
+	}
+
+	val, err := imp.Get("key")
+	if err != nil {
+		t.Errorf("unexpected error in Get: %v", err)
+	}
+
+	if val != "value2" {
+		t.Errorf("expected value %q, got %q", "value2", val)
+	}
+}
+
+func testSetIfPresentThenGet(t *testing.T, imp Geche[string, string]) {
+	if imp.SetIfPresent("key", "value") {
+		t.Errorf("expected SetIfPresent to not a new value for non-existing key")
+	}
+
+	val, err := imp.Get("key")
+	if err == nil {
+		t.Errorf("expected error not found in Get: %v", val)
+	}
+}
+
 func testGetNonExist(t *testing.T, imp Geche[string, string]) {
 	_, err := imp.Get("key")
 	if err != ErrNotFound {
@@ -200,6 +227,8 @@ func TestCommon(t *testing.T) {
 		{"Del", testDel},
 		{"DelOdd", testDelOdd},
 		{"SnapshotLen", testSnapshotLen},
+		{"SetSetIfPresentGet", testSetThenSetIfPresentThenGet},
+		{"SetIfPresentGet", testSetIfPresentThenGet},
 	}
 	for _, ci := range caches {
 		for _, tc := range tab {

--- a/doc.go
+++ b/doc.go
@@ -9,8 +9,8 @@ var ErrNotFound = errors.New("not found")
 // Geche interface is a common interface for all cache implementations.
 type Geche[K comparable, V any] interface {
 	Set(K, V)
-	// SetIfPresent sets the kv only if the key was already present, and returns whether the insertion was performed
-	SetIfPresent(K, V) bool
+	// SetIfPresent sets the kv only if the key was already present, and returns the previous value (if any) and whether the insertion was performed
+	SetIfPresent(K, V) (V, bool)
 	Get(K) (V, error)
 	Del(K) error
 	Snapshot() map[K]V

--- a/doc.go
+++ b/doc.go
@@ -9,6 +9,8 @@ var ErrNotFound = errors.New("not found")
 // Geche interface is a common interface for all cache implementations.
 type Geche[K comparable, V any] interface {
 	Set(K, V)
+	// SetIfPresent sets the kv only if the key was already present, and returns whether the insertion was performed
+	SetIfPresent(K, V) bool
 	Get(K) (V, error)
 	Del(K) error
 	Snapshot() map[K]V

--- a/dummy_test.go
+++ b/dummy_test.go
@@ -27,6 +27,19 @@ func (s *stringCache) Set(key, value string) {
 	s.data[key] = value
 }
 
+func (s *stringCache) SetIfPresent(key, value string) bool {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	_, ok := s.data[key]
+	if !ok {
+		return false
+	}
+
+	s.data[key] = value
+	return true
+}
+
 func (s *stringCache) Get(key string) (string, error) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
@@ -71,6 +84,15 @@ func (u *unsafeCache) Set(key, value string) {
 	u.data[key] = value
 }
 
+func (u *unsafeCache) SetIfPresent(key, value string) bool {
+	if _, err := u.Get(key); err != nil {
+		return false
+	}
+
+	u.Set(key, value)
+	return true
+}
+
 func (u *unsafeCache) Get(key string) (string, error) {
 	v, ok := u.data[key]
 	if !ok {
@@ -108,6 +130,18 @@ func (a *anyCache) Set(key string, value any) {
 	defer a.mux.Unlock()
 
 	a.data[key] = value
+}
+
+func (a *anyCache) SetIfPresent(key string, value any) bool {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+
+	_, ok := a.data[key]
+	if ok {
+		a.data[key] = value
+	}
+
+	return ok
 }
 
 func (a *anyCache) Get(key string) (any, error) {

--- a/dummy_test.go
+++ b/dummy_test.go
@@ -27,17 +27,17 @@ func (s *stringCache) Set(key, value string) {
 	s.data[key] = value
 }
 
-func (s *stringCache) SetIfPresent(key, value string) bool {
+func (s *stringCache) SetIfPresent(key, value string) (string, bool) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
-	_, ok := s.data[key]
+	old, ok := s.data[key]
 	if !ok {
-		return false
+		return "", false
 	}
 
 	s.data[key] = value
-	return true
+	return old, true
 }
 
 func (s *stringCache) Get(key string) (string, error) {
@@ -84,13 +84,14 @@ func (u *unsafeCache) Set(key, value string) {
 	u.data[key] = value
 }
 
-func (u *unsafeCache) SetIfPresent(key, value string) bool {
-	if _, err := u.Get(key); err != nil {
-		return false
+func (u *unsafeCache) SetIfPresent(key, value string) (string, bool) {
+	old, err := u.Get(key)
+	if err != nil {
+		return "", false
 	}
 
 	u.Set(key, value)
-	return true
+	return old, true
 }
 
 func (u *unsafeCache) Get(key string) (string, error) {

--- a/dummy_test.go
+++ b/dummy_test.go
@@ -132,18 +132,6 @@ func (a *anyCache) Set(key string, value any) {
 	a.data[key] = value
 }
 
-func (a *anyCache) SetIfPresent(key string, value any) bool {
-	a.mux.Lock()
-	defer a.mux.Unlock()
-
-	_, ok := a.data[key]
-	if ok {
-		a.data[key] = value
-	}
-
-	return ok
-}
-
 func (a *anyCache) Get(key string) (any, error) {
 	a.mux.RLock()
 	defer a.mux.RUnlock()

--- a/kv.go
+++ b/kv.go
@@ -113,16 +113,17 @@ func NewKV[V any](
 	return &kv
 }
 
-func (kv *KV[V]) SetIfPresent(key string, value V) bool {
+func (kv *KV[V]) SetIfPresent(key string, value V) (V, bool) {
 	kv.mux.Lock()
 	defer kv.mux.Unlock()
 
-	if _, err := kv.data.Get(key); err == nil {
+	previousVal, err := kv.data.Get(key)
+	if err == nil {
 		kv.set(key, value)
-		return true
+		return previousVal, true
 	}
 
-	return false
+	return previousVal, false
 }
 
 // Set key-value pair while updating the trie.

--- a/kv.go
+++ b/kv.go
@@ -113,124 +113,25 @@ func NewKV[V any](
 	return &kv
 }
 
+func (kv *KV[V]) SetIfPresent(key string, value V) bool {
+	kv.mux.Lock()
+	defer kv.mux.Unlock()
+
+	if _, err := kv.data.Get(key); err == nil {
+		kv.set(key, value)
+		return true
+	}
+
+	return false
+}
+
 // Set key-value pair while updating the trie.
 // Panics if key is empty.
 func (kv *KV[V]) Set(key string, value V) {
 	kv.mux.Lock()
 	defer kv.mux.Unlock()
 
-	kv.data.Set(key, value)
-
-	if key == "" {
-		kv.trie.terminal = true
-		return
-	}
-
-	keyb := []byte(key)
-	node := kv.trie
-	for len(keyb) > 0 {
-		if node.down == nil {
-			// Creating new level.
-			node.down = make(map[byte]*trieNode)
-		}
-
-		next := node.down[keyb[0]]
-		if next == nil {
-			// Creating new node.
-			next = &trieNode{
-				b: keyb,
-				d: node.d + 1,
-			}
-			node.down[keyb[0]] = next
-			if node.nextLevelHead == nil {
-				node.nextLevelHead = next
-			} else {
-				// Adding node to the linked list.
-				head := node.nextLevelHead.addToList(next)
-				if head != nil {
-					node.nextLevelHead = head
-				}
-			}
-		} else if len(next.b) == 1 {
-			// Single byte nodes are a simple case.
-		} else {
-			// Multi byte nodes require splitting.
-
-			// Removing node from the linked list.
-			head, empty := node.nextLevelHead.removeFromList(keyb[0])
-			if empty {
-				node.nextLevelHead = nil
-			} else if head != nil {
-				node.nextLevelHead = head
-			}
-
-			commonPrefixLen := commonPrefixLen(keyb, next.b)
-			for i := 0; i < commonPrefixLen; i++ {
-				// Creating new single-byte node.
-				newNode := &trieNode{
-					b:    []byte{keyb[i]},
-					d:    node.d + 1,
-					down: make(map[byte]*trieNode),
-				}
-				node.down[keyb[i]] = newNode
-				if node.nextLevelHead == nil {
-					node.nextLevelHead = newNode
-				} else {
-					head := node.nextLevelHead.addToList(newNode)
-					if head != nil {
-						node.nextLevelHead = head
-					}
-				}
-
-				node = newNode
-			}
-
-			if (bytes.Equal(next.b, keyb[:commonPrefixLen]) && next.terminal) || len(keyb) == commonPrefixLen {
-				// If last node is end of key, or end of the node we are splitting, mark it as terminal.
-				node.terminal = true
-			}
-
-			// Adding removed node back.
-			if len(next.b) > commonPrefixLen {
-				// Creating new suffix (potentially multi-byte) node.
-				newNode := &trieNode{
-					b:        next.b[commonPrefixLen:],
-					d:        node.d + 1,
-					terminal: true,
-				}
-				node.down[next.b[commonPrefixLen]] = newNode
-				node.nextLevelHead = newNode
-			}
-
-			// Adding new tail node.
-			if len(keyb) > commonPrefixLen {
-				// Creating new suffix (potentially multi-byte) node.
-				newNode := &trieNode{
-					b:        keyb[commonPrefixLen:],
-					d:        node.d + 1,
-					terminal: true,
-				}
-				node.down[keyb[commonPrefixLen]] = newNode
-				if node.nextLevelHead == nil {
-					node.nextLevelHead = newNode
-				} else {
-					head := node.nextLevelHead.addToList(newNode)
-					if head != nil {
-						node.nextLevelHead = head
-					}
-				}
-			}
-
-			// keyb = keyb[commonPrefixLen:]
-			// continue
-			return
-		}
-
-		keyb = keyb[commonPrefixLen(keyb, next.b):]
-		node = next
-	}
-
-	node.terminal = true
+	kv.set(key, value)
 }
 
 func commonPrefixLen(a, b []byte) int {
@@ -382,7 +283,7 @@ func (kv *KV[V]) Del(key string) error {
 		// If we are here, the key does not exist.
 		return kv.data.Del(key)
 	}
-	
+
 	node.terminal = false
 
 	// Go back the stack removing nodes with no descendants.
@@ -417,4 +318,119 @@ func (kv *KV[V]) Snapshot() map[string]V {
 // Len returns total number of elements in the underlying caches.
 func (kv *KV[V]) Len() int {
 	return kv.data.Len()
+}
+
+func (kv *KV[V]) set(key string, value V) {
+	kv.data.Set(key, value)
+
+	if key == "" {
+		kv.trie.terminal = true
+		return
+	}
+
+	keyb := []byte(key)
+	node := kv.trie
+	for len(keyb) > 0 {
+		if node.down == nil {
+			// Creating new level.
+			node.down = make(map[byte]*trieNode)
+		}
+
+		next := node.down[keyb[0]]
+		if next == nil {
+			// Creating new node.
+			next = &trieNode{
+				b: keyb,
+				d: node.d + 1,
+			}
+			node.down[keyb[0]] = next
+			if node.nextLevelHead == nil {
+				node.nextLevelHead = next
+			} else {
+				// Adding node to the linked list.
+				head := node.nextLevelHead.addToList(next)
+				if head != nil {
+					node.nextLevelHead = head
+				}
+			}
+		} else if len(next.b) == 1 {
+			// Single byte nodes are a simple case.
+		} else {
+			// Multi byte nodes require splitting.
+
+			// Removing node from the linked list.
+			head, empty := node.nextLevelHead.removeFromList(keyb[0])
+			if empty {
+				node.nextLevelHead = nil
+			} else if head != nil {
+				node.nextLevelHead = head
+			}
+
+			commonPrefixLen := commonPrefixLen(keyb, next.b)
+			for i := 0; i < commonPrefixLen; i++ {
+				// Creating new single-byte node.
+				newNode := &trieNode{
+					b:    []byte{keyb[i]},
+					d:    node.d + 1,
+					down: make(map[byte]*trieNode),
+				}
+				node.down[keyb[i]] = newNode
+				if node.nextLevelHead == nil {
+					node.nextLevelHead = newNode
+				} else {
+					head := node.nextLevelHead.addToList(newNode)
+					if head != nil {
+						node.nextLevelHead = head
+					}
+				}
+
+				node = newNode
+			}
+
+			if (bytes.Equal(next.b, keyb[:commonPrefixLen]) && next.terminal) || len(keyb) == commonPrefixLen {
+				// If last node is end of key, or end of the node we are splitting, mark it as terminal.
+				node.terminal = true
+			}
+
+			// Adding removed node back.
+			if len(next.b) > commonPrefixLen {
+				// Creating new suffix (potentially multi-byte) node.
+				newNode := &trieNode{
+					b:        next.b[commonPrefixLen:],
+					d:        node.d + 1,
+					terminal: true,
+				}
+				node.down[next.b[commonPrefixLen]] = newNode
+				node.nextLevelHead = newNode
+			}
+
+			// Adding new tail node.
+			if len(keyb) > commonPrefixLen {
+				// Creating new suffix (potentially multi-byte) node.
+				newNode := &trieNode{
+					b:        keyb[commonPrefixLen:],
+					d:        node.d + 1,
+					terminal: true,
+				}
+				node.down[keyb[commonPrefixLen]] = newNode
+				if node.nextLevelHead == nil {
+					node.nextLevelHead = newNode
+				} else {
+					head := node.nextLevelHead.addToList(newNode)
+					if head != nil {
+						node.nextLevelHead = head
+					}
+				}
+			}
+
+			// keyb = keyb[commonPrefixLen:]
+			// continue
+			return
+		}
+
+		keyb = keyb[commonPrefixLen(keyb, next.b):]
+		node = next
+	}
+
+	node.terminal = true
 }

--- a/kv_test.go
+++ b/kv_test.go
@@ -768,17 +768,15 @@ func TestSetIfPresentConcurrent(t *testing.T) {
 				kv.SetIfPresent("c", "c")
 			case 3:
 				_, _ = kv.Get("a")
-				time.Sleep(5 * time.Millisecond)
 			case 4:
 				_, _ = kv.Get("b")
-				time.Sleep(5 * time.Millisecond)
 			case 5:
 				_, _ = kv.Get("c")
-				time.Sleep(5 * time.Millisecond)
 			}
 		}()
-
 	}
+
+	time.Sleep(10 * time.Millisecond)
 
 	if val, _ := kv.Get("a"); val != "a" {
 		t.Errorf("expected %q, got %q", "a", val)

--- a/locker.go
+++ b/locker.go
@@ -82,7 +82,7 @@ func (tx *Tx[K, V]) Set(key K, value V) {
 	tx.cache.Set(key, value)
 }
 
-func (tx *Tx[K, V]) SetIfPresent(key K, value V) bool {
+func (tx *Tx[K, V]) SetIfPresent(key K, value V) (V, bool) {
 	if atomic.LoadInt32(&tx.unlocked) == 1 {
 		panic("cannot use unlocked transaction")
 	}

--- a/locker.go
+++ b/locker.go
@@ -82,6 +82,16 @@ func (tx *Tx[K, V]) Set(key K, value V) {
 	tx.cache.Set(key, value)
 }
 
+func (tx *Tx[K, V]) SetIfPresent(key K, value V) bool {
+	if atomic.LoadInt32(&tx.unlocked) == 1 {
+		panic("cannot use unlocked transaction")
+	}
+	if !tx.writable {
+		panic("cannot set in read-only transaction")
+	}
+	return tx.cache.SetIfPresent(key, value)
+}
+
 // Get value by key from the underlying sharded cache.
 func (tx *Tx[K, V]) Get(key K) (V, error) {
 	if atomic.LoadInt32(&tx.unlocked) == 1 {

--- a/map.go
+++ b/map.go
@@ -25,16 +25,17 @@ func (c *MapCache[K, V]) Set(key K, value V) {
 	c.data[key] = value
 }
 
-func (c *MapCache[K, V]) SetIfPresent(key K, value V) bool {
+func (c *MapCache[K, V]) SetIfPresent(key K, value V) (V, bool) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	if _, ok := c.data[key]; ok {
+	old, ok := c.data[key]
+	if ok {
 		c.data[key] = value
-		return true
+		return old, true
 	}
 
-	return false
+	return old, false
 }
 
 // Get returns ErrNotFound if key does not exist in the cache.

--- a/map.go
+++ b/map.go
@@ -25,6 +25,18 @@ func (c *MapCache[K, V]) Set(key K, value V) {
 	c.data[key] = value
 }
 
+func (c *MapCache[K, V]) SetIfPresent(key K, value V) bool {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if _, ok := c.data[key]; ok {
+		c.data[key] = value
+		return true
+	}
+
+	return false
+}
+
 // Get returns ErrNotFound if key does not exist in the cache.
 func (c *MapCache[K, V]) Get(key K) (V, error) {
 	c.mux.RLock()

--- a/map_ttl.go
+++ b/map_ttl.go
@@ -77,16 +77,17 @@ func (c *MapTTLCache[K, V]) Set(key K, value V) {
 }
 
 // SetIfPresent sets the given key to the given value if the key was already present, and resets the TTL
-func (c *MapTTLCache[K, V]) SetIfPresent(key K, value V) bool {
+func (c *MapTTLCache[K, V]) SetIfPresent(key K, value V) (V, bool) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	if _, err := c.get(key); err == nil {
+	old, err := c.get(key)
+	if err == nil {
 		c.set(key, value)
-		return true
+		return old, true
 	}
 
-	return false
+	return old, false
 }
 
 // Get returns ErrNotFound if key is not found in the cache or record is outdated.

--- a/map_ttl.go
+++ b/map_ttl.go
@@ -73,38 +73,20 @@ func NewMapTTLCache[K comparable, V any](
 func (c *MapTTLCache[K, V]) Set(key K, value V) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
+	c.set(key, value)
+}
 
-	val := ttlRec[K, V]{
-		value:     value,
-		prev:      c.tail,
-		timestamp: c.now(),
+// SetIfPresent sets the given key to the given value if the key was already present, and resets the TTL
+func (c *MapTTLCache[K, V]) SetIfPresent(key K, value V) bool {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if _, err := c.get(key); err == nil {
+		c.set(key, value)
+		return true
 	}
 
-	if c.head == c.zero {
-		c.head = key
-		c.tail = key
-		val.prev = c.zero
-		c.data[key] = val
-		return
-	}
-
-	// If the record for this key already exists
-	// and is somewhere in the middle of the list
-	// removing it before adding to the tail.
-	if rec, ok := c.data[key]; ok && key != c.tail {
-		prev := c.data[rec.prev]
-		next := c.data[rec.next]
-		prev.next = rec.next
-		next.prev = rec.prev
-		c.data[rec.prev] = prev
-		c.data[rec.next] = next
-	}
-
-	tailval := c.data[c.tail]
-	tailval.next = key
-	c.data[c.tail] = tailval
-	c.tail = key
-	c.data[key] = val
+	return false
 }
 
 // Get returns ErrNotFound if key is not found in the cache or record is outdated.
@@ -112,16 +94,7 @@ func (c *MapTTLCache[K, V]) Get(key K) (V, error) {
 	c.mux.RLock()
 	defer c.mux.RUnlock()
 
-	v, ok := c.data[key]
-	if !ok {
-		return v.value, ErrNotFound
-	}
-
-	if c.now().Sub(v.timestamp) >= c.ttl {
-		return v.value, ErrNotFound
-	}
-
-	return v.value, nil
+	return c.get(key)
 }
 
 func (c *MapTTLCache[K, V]) Del(key K) error {
@@ -207,11 +180,57 @@ func (c *MapTTLCache[K, V]) Snapshot() map[K]V {
 	return snapshot
 }
 
-
 // Len returns the number of records in the cache.
 func (c *MapTTLCache[K, V]) Len() int {
 	c.mux.RLock()
 	defer c.mux.RUnlock()
 
 	return len(c.data)
+}
+
+func (c *MapTTLCache[K, V]) set(key K, value V) {
+	val := ttlRec[K, V]{
+		value:     value,
+		prev:      c.tail,
+		timestamp: c.now(),
+	}
+
+	if c.head == c.zero {
+		c.head = key
+		c.tail = key
+		val.prev = c.zero
+		c.data[key] = val
+		return
+	}
+
+	// If the record for this key already exists
+	// and is somewhere in the middle of the list
+	// removing it before adding to the tail.
+	if rec, ok := c.data[key]; ok && key != c.tail {
+		prev := c.data[rec.prev]
+		next := c.data[rec.next]
+		prev.next = rec.next
+		next.prev = rec.prev
+		c.data[rec.prev] = prev
+		c.data[rec.next] = next
+	}
+
+	tailval := c.data[c.tail]
+	tailval.next = key
+	c.data[c.tail] = tailval
+	c.tail = key
+	c.data[key] = val
+}
+
+func (c *MapTTLCache[K, V]) get(key K) (V, error) {
+	v, ok := c.data[key]
+	if !ok {
+		return v.value, ErrNotFound
+	}
+
+	if c.now().Sub(v.timestamp) >= c.ttl {
+		return v.value, ErrNotFound
+	}
+
+	return v.value, nil
 }

--- a/ring.go
+++ b/ring.go
@@ -41,16 +41,18 @@ func (c *RingBuffer[K, V]) Set(key K, value V) {
 	c.set(key, value)
 }
 
-func (c *RingBuffer[K, V]) SetIfPresent(key K, value V) bool {
+func (c *RingBuffer[K, V]) SetIfPresent(key K, value V) (V, bool) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	if _, present := c.index[key]; present {
+	i, present := c.index[key]
+	if present {
+		oldVal := c.data[i].value
 		c.set(key, value)
-		return true
+		return oldVal, present
 	}
 
-	return false
+	return c.zeroV, false
 }
 
 // Get returns cached value for the key, or ErrNotFound if the key does not exist.

--- a/ring_test.go
+++ b/ring_test.go
@@ -13,7 +13,7 @@ func TestRing(t *testing.T) {
 		c.Set(s, s)
 	}
 
-	// Check the value does not exist (overwriten).
+	// Check the value does not exist (overwritten).
 	for i := 0; i < 5; i++ {
 		s := strconv.Itoa(i)
 		if _, err := c.Get(s); err != ErrNotFound {
@@ -22,15 +22,29 @@ func TestRing(t *testing.T) {
 	}
 
 	// Check we can get the value.
-	for i := 5; i < 15; i++ {
-		s := strconv.Itoa(i)
-		val, err := c.Get(s)
-		if err != nil {
-			t.Errorf("unexpected error in Get(%q): %v", s, err)
-		}
+	checkExistingKeys := func() {
+		for i := 5; i < 15; i++ {
+			s := strconv.Itoa(i)
+			val, err := c.Get(s)
+			if err != nil {
+				t.Errorf("unexpected error in Get(%q): %v", s, err)
+			}
 
-		if val != s {
-			t.Errorf("expected value %q, but got %q", s, val)
+			if val != s {
+				t.Errorf("expected value %q, but got %q", s, val)
+			}
 		}
 	}
+	checkExistingKeys()
+
+	// SetIfPresent on existing key or non-existing key does not result in eviction
+	for i := range []int{0, 5, 14} {
+		c.SetIfPresent(strconv.Itoa(i), strconv.Itoa(i))
+	}
+
+	if _, err := c.Get(strconv.Itoa(0)); err != ErrNotFound {
+		t.Errorf("Get(%d): expected ErrNotFound, but got %v", 0, err)
+	}
+
+	checkExistingKeys()
 }

--- a/ring_test.go
+++ b/ring_test.go
@@ -38,12 +38,24 @@ func TestRing(t *testing.T) {
 	checkExistingKeys()
 
 	// SetIfPresent on existing key or non-existing key does not result in eviction
-	for i := range []int{0, 5, 14} {
-		c.SetIfPresent(strconv.Itoa(i), strconv.Itoa(i))
+	_, inserted := c.SetIfPresent(strconv.Itoa(0), strconv.Itoa(0))
+	if inserted {
+		t.Error("SetIfPresent returned inserted=true for non-existing key 0")
 	}
 
 	if _, err := c.Get(strconv.Itoa(0)); err != ErrNotFound {
 		t.Errorf("Get(%d): expected ErrNotFound, but got %v", 0, err)
+	}
+
+	for _, i := range []int{5, 6, 14} {
+		old, inserted := c.SetIfPresent(strconv.Itoa(i), strconv.Itoa(i))
+		if !inserted {
+			t.Error("SetIfPresent returned inserted=false for existing key")
+		}
+
+		if old != strconv.Itoa(i) {
+			t.Errorf("SetIfPresent returned incorrect old value, expected %d, got %s", i, old)
+		}
 	}
 
 	checkExistingKeys()

--- a/shard.go
+++ b/shard.go
@@ -75,7 +75,7 @@ func (s *Sharded[K, V]) Set(key K, value V) {
 	s.shards[s.mapper.Map(key, s.N)].Set(key, value)
 }
 
-func (s *Sharded[K, V]) SetIfPresent(key K, value V) bool {
+func (s *Sharded[K, V]) SetIfPresent(key K, value V) (V, bool) {
 	return s.shards[s.mapper.Map(key, s.N)].SetIfPresent(key, value)
 }
 

--- a/shard.go
+++ b/shard.go
@@ -75,6 +75,10 @@ func (s *Sharded[K, V]) Set(key K, value V) {
 	s.shards[s.mapper.Map(key, s.N)].Set(key, value)
 }
 
+func (s *Sharded[K, V]) SetIfPresent(key K, value V) bool {
+	return s.shards[s.mapper.Map(key, s.N)].SetIfPresent(key, value)
+}
+
 // Get value by key from the underlying sharded cache.
 func (s *Sharded[K, V]) Get(key K) (V, error) {
 	return s.shards[s.mapper.Map(key, s.N)].Get(key)

--- a/shard_test.go
+++ b/shard_test.go
@@ -66,8 +66,22 @@ func TestSharded(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 2000; i++ {
-		c.SetIfPresent(i, "modified")
+	for i := 0; i < 1000; i++ {
+		old, inserted := c.SetIfPresent(i, "modified")
+		if !inserted {
+			t.Fatalf("SetIfPresent returned inserted=false for existing key %d", i)
+		}
+
+		if old != strconv.Itoa(i) {
+			t.Fatalf("SetIfPresent returned unexpected old value, expected=%d, got=%s", i, old)
+		}
+	}
+
+	for i := 1000; i < 2000; i++ {
+		_, inserted := c.SetIfPresent(i, "modified")
+		if inserted {
+			t.Fatalf("SetIfPresent returned inserted=true for non-existing key %d", i)
+		}
 	}
 
 	for i := 0; i < 1000; i++ {

--- a/shard_test.go
+++ b/shard_test.go
@@ -17,7 +17,6 @@ func ExampleNewSharded() {
 		&NumberMapper[int]{},
 	)
 
-
 	// Set 4000 records in 4 parallel goroutines.
 	wg := sync.WaitGroup{}
 	wg.Add(numShards)
@@ -64,6 +63,28 @@ func TestSharded(t *testing.T) {
 
 		if v != strconv.Itoa(i) {
 			t.Fatalf("key %d with unexpected value %q", i, v)
+		}
+	}
+
+	for i := 0; i < 2000; i++ {
+		c.SetIfPresent(i, "modified")
+	}
+
+	for i := 0; i < 1000; i++ {
+		v, err := c.Get(i)
+		if err != nil {
+			t.Fatalf("unexpected error in Get: %v", err)
+		}
+
+		if v != "modified" {
+			t.Fatalf("key %d with unexpected value %q", i, v)
+		}
+	}
+
+	for i := 1000; i < 2000; i++ {
+		_, err := c.Get(i)
+		if err == nil {
+			t.Fatalf("expected error in Get")
 		}
 	}
 

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -173,3 +173,29 @@ func TestTTLScenario(t *testing.T) {
 		t.Errorf("expected cache data len to be 5 but got %d", len(c.data))
 	}
 }
+
+func TestSetIfPresentResetsTTL(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := NewMapTTLCache[string, string](ctx, time.Second, time.Second)
+
+	ts := time.Now()
+
+	c.Set("key", "value")
+	c.mux.Lock()
+	c.now = func() time.Time { return ts.Add(time.Second) }
+	c.mux.Unlock()
+
+	if !c.SetIfPresent("key", "value2") {
+		t.Errorf("expected key to be set as it is present in the map, but SetIfPresent returned false")
+	}
+
+	v, err := c.Get("key")
+	if err != nil {
+		t.Errorf("unexpected error in Get: %v", err)
+	}
+
+	if v != "value2" {
+		t.Errorf("value was not updated by SetIfPresent, expected %v, but got %v", "value2", v)
+	}
+}

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -186,8 +186,13 @@ func TestSetIfPresentResetsTTL(t *testing.T) {
 	c.now = func() time.Time { return ts.Add(time.Second) }
 	c.mux.Unlock()
 
-	if !c.SetIfPresent("key", "value2") {
+	old, inserted := c.SetIfPresent("key", "value2")
+	if !inserted {
 		t.Errorf("expected key to be set as it is present in the map, but SetIfPresent returned false")
+	}
+
+	if old != "value" {
+		t.Errorf("expected old value %q, but got %q", "value", old)
 	}
 
 	v, err := c.Get("key")

--- a/updater.go
+++ b/updater.go
@@ -59,7 +59,7 @@ func (u *Updater[K, V]) Set(key K, value V) {
 	u.cache.Set(key, value)
 }
 
-func (u *Updater[K, V]) SetIfPresent(key K, value V) bool {
+func (u *Updater[K, V]) SetIfPresent(key K, value V) (V, bool) {
 	return u.cache.SetIfPresent(key, value)
 }
 

--- a/updater.go
+++ b/updater.go
@@ -59,6 +59,10 @@ func (u *Updater[K, V]) Set(key K, value V) {
 	u.cache.Set(key, value)
 }
 
+func (u *Updater[K, V]) SetIfPresent(key K, value V) bool {
+	return u.cache.SetIfPresent(key, value)
+}
+
 // Get returns value from the cache. If the value is not in the cache,
 // it calls updateFn to get the value and update the cache first.
 // Since updateFn can return error, Get is not guaranteed to always return the value.


### PR DESCRIPTION
Added to all implementations and most tests

`SetIfPresent` sets the provided key to the provided value if it already exists in the cache implementation. For `MapTTLCache`, it also reinitializes the TTL