### PR TITLE
Functions to access RingBuffer in ordered manner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v3
       with:
-        go-version: "1.21"
+        go-version: "1.24"
     - uses: golangci/golangci-lint-action@v3
       with:
-          version: v1.51
+          version: v2.1.6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Scan the code
-      run: /osv-scanner -r --skip-git . || if [ $? -eq 128 ]; then true; else exit $?; fi
+      run: /osv-scanner -r . || if [ $? -eq 128 ]; then true; else exit $?; fi
   golangci-lint:
     name: Run golangci-lint
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,6 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: "1.24"
-    - uses: golangci/golangci-lint-action@v3
+    - uses: golangci/golangci-lint-action@v8
       with:
           version: v2.1.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20"
+        go-version: "1.24"
 
     - name: Test
       run: go test -v -covermode=atomic -coverprofile=coverage.out -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/c-pro/geche
 
-go 1.20
+go 1.24

--- a/kv.go
+++ b/kv.go
@@ -176,11 +176,7 @@ func (kv *KV[V]) dfs(node *trieNode, prefix []byte) ([]V, error) {
 		err       error
 		val       V
 	)
-	for {
-		if len(stack) == 0 {
-			break
-		}
-
+	for len(stack) > 0 {
 		// Pop the top node from the stack.
 		top = stack[len(stack)-1]
 		stack = stack[:len(stack)-1]

--- a/kv.go
+++ b/kv.go
@@ -293,7 +293,7 @@ func (kv *KV[V]) Del(key string) error {
 		stack = stack[:i]
 		if node.nextLevelHead == nil {
 			head, empty := prev.nextLevelHead.removeFromList(node.b[0])
-			if head != nil || (head == nil && empty) {
+			if head != nil || empty {
 				prev.nextLevelHead = head
 			}
 			delete(prev.down, node.b[0])

--- a/kv_test.go
+++ b/kv_test.go
@@ -900,10 +900,11 @@ func FuzzMonkey(f *testing.F) {
 		task := randTask(seed)
 		golden := make(map[string]struct{}, len(task))
 		for _, cmd := range task {
-			if cmd.action == "Set" {
+			switch cmd.action {
+			case "Set":
 				kv.Set(cmd.key, cmd.key)
 				golden[cmd.key] = struct{}{}
-			} else if cmd.action == "Del" {
+			case "Del":
 				// Since keys are random we expect a lot of Del to fail.
 				_ = kv.Del(cmd.key)
 				delete(golden, cmd.key)

--- a/ring.go
+++ b/ring.go
@@ -174,7 +174,7 @@ func (c *RingBuffer[K, V]) ListAllKeys() []K {
 }
 
 // All is a (read-only) iterator over all key-value pairs in the cache.
-// Attempt to modify the cache (Set/Del, etc.) while iterating will read to
+// Attempt to modify the cache (Set/Del, etc.) while iterating will lead to
 // a deadlock.
 func (c *RingBuffer[K, V]) All() iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {

--- a/ring_test.go
+++ b/ring_test.go
@@ -1,6 +1,7 @@
 package geche
 
 import (
+	"math/rand"
 	"strconv"
 	"testing"
 )
@@ -18,6 +19,37 @@ func TestRing(t *testing.T) {
 		s := strconv.Itoa(i)
 		if _, err := c.Get(s); err != ErrNotFound {
 			t.Errorf("Get(%q): expected error %v, but got %v", s, ErrNotFound, err)
+		}
+	}
+
+	expected := []struct {
+		K string
+		V string
+	}{
+		{"5", "5"},
+		{"6", "6"},
+		{"7", "7"},
+		{"8", "8"},
+		{"9", "9"},
+		{"10", "10"},
+		{"11", "11"},
+		{"12", "12"},
+		{"13", "13"},
+		{"14", "14"},
+	}
+
+	got := c.ListAll()
+	if len(got) != len(expected) {
+		t.Errorf("expected %d items, but got %d", len(expected), len(got))
+	}
+
+	for i, item := range got {
+		if item.K != expected[i].K || item.V != expected[i].V {
+			t.Errorf(
+				"expected item %s:%s, but got %s:%s",
+				expected[i].K, expected[i].V,
+				item.K, item.V,
+			)
 		}
 	}
 
@@ -59,4 +91,54 @@ func TestRing(t *testing.T) {
 	}
 
 	checkExistingKeys()
+}
+
+func TestRingListAll(t *testing.T) {
+	c := NewRingBuffer[int, int](10)
+
+	// This will emulate the expected behavior of the ring buffer.
+	slice := make([]int, 0, 10)
+
+	for i := 0; i < 10000; i++ {
+		c.Set(i, i)
+
+		slice = append(slice, i)
+		if len(slice) > 10 {
+			slice = slice[1:]
+		}
+
+		if rand.Intn(10) == 0 {
+			// Randomly remove an item from the ring buffer.
+			toDelIdx := rand.Intn(len(slice))
+			toDelKey := slice[toDelIdx]
+			c.Del(toDelKey)
+			// Mark item as deleted in the slice.
+			// Acrually deleting from the slice wont'b reflect in the ring buffer,
+			// as deleted value still takes space in the ring buffer.
+			slice[toDelIdx] = -1
+		}
+
+		expected := make([]BufferRec[int, int], 0, len(slice))
+		for _, v := range slice {
+			if v == -1 {
+				continue
+			}
+			expected = append(expected, BufferRec[int, int]{K: v, V: v})
+		}
+
+		got := c.ListAll()
+		if len(got) != len(expected) {
+			t.Fatalf("expected %d items, but got %d", len(expected), len(got))
+		}
+
+		for j, item := range got {
+			if item.K != expected[j].K || item.V != expected[j].V {
+				t.Fatalf(
+					"expected item %d:%d, but got %d:%d",
+					expected[j].K, expected[j].V,
+					item.K, item.V,
+				)
+			}
+		}
+	}
 }

--- a/ring_test.go
+++ b/ring_test.go
@@ -111,7 +111,9 @@ func TestRingListAll(t *testing.T) {
 			// Randomly remove an item from the ring buffer.
 			toDelIdx := rand.Intn(len(slice))
 			toDelKey := slice[toDelIdx]
-			c.Del(toDelKey)
+			if err := c.Del(toDelKey); err != nil {
+				t.Fatalf("unexpected error in Del(%d): %v", toDelKey, err)
+			}
 			// Mark item as deleted in the slice.
 			// Acrually deleting from the slice wont'b reflect in the ring buffer,
 			// as deleted value still takes space in the ring buffer.
@@ -161,7 +163,9 @@ func TestRingListAllValues(t *testing.T) {
 			// Randomly remove an item from the ring buffer.
 			toDelIdx := rand.Intn(len(slice))
 			toDelKey := slice[toDelIdx]
-			c.Del(toDelKey)
+			if err := c.Del(toDelKey); err != nil {
+				t.Fatalf("unexpected error in Del(%d): %v", toDelKey, err)
+			}
 			// Mark item as deleted in the slice.
 			slice[toDelIdx] = -1
 		}
@@ -208,7 +212,9 @@ func TestRingListAllKeys(t *testing.T) {
 			// Randomly remove an item from the ring buffer.
 			toDelIdx := rand.Intn(len(slice))
 			toDelKey := slice[toDelIdx]
-			c.Del(toDelKey)
+			if err := c.Del(toDelKey); err != nil {
+				t.Fatalf("unexpected error in Del(%d): %v", toDelKey, err)
+			}
 			// Mark item as deleted in the slice.
 			slice[toDelIdx] = -1
 		}
@@ -255,7 +261,9 @@ func TestRingAllIterator(t *testing.T) {
 			// Randomly remove an item from the ring buffer.
 			toDelIdx := rand.Intn(len(slice))
 			toDelKey := slice[toDelIdx]
-			c.Del(toDelKey)
+			if err := c.Del(toDelKey); err != nil {
+				t.Fatalf("unexpected error in Del(%d): %v", toDelKey, err)
+			}
 			// Mark item as deleted in the slice.
 			slice[toDelIdx] = -1
 		}
@@ -420,8 +428,12 @@ func TestRingListAll_AllDeleted(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
 	c.Set(1, 10)
 	c.Set(2, 20)
-	c.Del(1)
-	c.Del(2)
+	if err := c.Del(1); err != nil {
+		t.Errorf("unexpected error in Del(1): %v", err)
+	}
+	if err := c.Del(2); err != nil {
+		t.Errorf("unexpected error in Del(2): %v", err)
+	}
 	if testing.Verbose() {
 		t.Log("Testing ListAll with all elements deleted")
 	}
@@ -435,8 +447,12 @@ func TestRingListAllValues_AllDeleted(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
 	c.Set(1, 10)
 	c.Set(2, 20)
-	c.Del(1)
-	c.Del(2)
+	if err := c.Del(1); err != nil {
+		t.Errorf("unexpected error in Del(1): %v", err)
+	}
+	if err := c.Del(2); err != nil {
+		t.Errorf("unexpected error in Del(2): %v", err)
+	}
 	if testing.Verbose() {
 		t.Log("Testing ListAllValues with all elements deleted")
 	}
@@ -450,8 +466,12 @@ func TestRingListAllKeys_AllDeleted(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
 	c.Set(1, 10)
 	c.Set(2, 20)
-	c.Del(1)
-	c.Del(2)
+	if err := c.Del(1); err != nil {
+		t.Errorf("unexpected error in Del(1): %v", err)
+	}
+	if err := c.Del(2); err != nil {
+		t.Errorf("unexpected error in Del(2): %v", err)
+	}
 	if testing.Verbose() {
 		t.Log("Testing ListAllKeys with all elements deleted")
 	}
@@ -465,8 +485,12 @@ func TestRingAllIterator_AllDeleted(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
 	c.Set(1, 10)
 	c.Set(2, 20)
-	c.Del(1)
-	c.Del(2)
+	if err := c.Del(1); err != nil {
+		t.Errorf("unexpected error in Del(1): %v", err)
+	}
+	if err := c.Del(2); err != nil {
+		t.Errorf("unexpected error in Del(2): %v", err)
+	}
 	if testing.Verbose() {
 		t.Log("Testing All iterator with all elements deleted")
 	}

--- a/ring_test.go
+++ b/ring_test.go
@@ -299,11 +299,6 @@ func TestRingAllIterator(t *testing.T) {
 
 func TestRingListAll_Empty(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
-
-	if testing.Verbose() {
-		t.Log("Testing ListAll on an empty buffer")
-	}
-
 	got := c.ListAll()
 	if len(got) != 0 {
 		t.Errorf("expected 0 items, but got %d", len(got))
@@ -312,9 +307,6 @@ func TestRingListAll_Empty(t *testing.T) {
 
 func TestRingListAllValues_Empty(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
-	if testing.Verbose() {
-		t.Log("Testing ListAllValues on an empty buffer")
-	}
 	got := c.ListAllValues()
 	if len(got) != 0 {
 		t.Errorf("expected 0 values, but got %d", len(got))
@@ -323,9 +315,6 @@ func TestRingListAllValues_Empty(t *testing.T) {
 
 func TestRingListAllKeys_Empty(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
-	if testing.Verbose() {
-		t.Log("Testing ListAllKeys on an empty buffer")
-	}
 	got := c.ListAllKeys()
 	if len(got) != 0 {
 		t.Errorf("expected 0 keys, but got %d", len(got))
@@ -334,9 +323,6 @@ func TestRingListAllKeys_Empty(t *testing.T) {
 
 func TestRingAllIterator_Empty(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
-	if testing.Verbose() {
-		t.Log("Testing All iterator on an empty buffer")
-	}
 	iter := c.All()
 	count := 0
 	for range iter {
@@ -350,10 +336,6 @@ func TestRingAllIterator_Empty(t *testing.T) {
 func TestRingListAll_OneElement(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
 	c.Set(1, 10)
-	if testing.Verbose() {
-		t.Log("Testing ListAll with one element")
-	}
-
 	expected := []BufferRec[int, int]{{K: 1, V: 10}}
 	got := c.ListAll()
 	if len(got) != len(expected) {
@@ -369,9 +351,6 @@ func TestRingListAll_OneElement(t *testing.T) {
 func TestRingListAllValues_OneElement(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
 	c.Set(1, 10)
-	if testing.Verbose() {
-		t.Log("Testing ListAllValues with one element")
-	}
 	expected := []int{10}
 	got := c.ListAllValues()
 	if len(got) != len(expected) {
@@ -387,9 +366,6 @@ func TestRingListAllValues_OneElement(t *testing.T) {
 func TestRingListAllKeys_OneElement(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
 	c.Set(1, 10)
-	if testing.Verbose() {
-		t.Log("Testing ListAllKeys with one element")
-	}
 	expected := []int{1}
 	got := c.ListAllKeys()
 	if len(got) != len(expected) {
@@ -405,9 +381,6 @@ func TestRingListAllKeys_OneElement(t *testing.T) {
 func TestRingAllIterator_OneElement(t *testing.T) {
 	c := NewRingBuffer[int, int](5)
 	c.Set(1, 10)
-	if testing.Verbose() {
-		t.Log("Testing All iterator with one element")
-	}
 	expectedItems := []BufferRec[int, int]{{K: 1, V: 10}}
 	iter := c.All()
 	var gotItems []BufferRec[int, int]
@@ -434,9 +407,6 @@ func TestRingListAll_AllDeleted(t *testing.T) {
 	if err := c.Del(2); err != nil {
 		t.Errorf("unexpected error in Del(2): %v", err)
 	}
-	if testing.Verbose() {
-		t.Log("Testing ListAll with all elements deleted")
-	}
 	got := c.ListAll()
 	if len(got) != 0 {
 		t.Errorf("expected 0 items, but got %d", len(got))
@@ -452,9 +422,6 @@ func TestRingListAllValues_AllDeleted(t *testing.T) {
 	}
 	if err := c.Del(2); err != nil {
 		t.Errorf("unexpected error in Del(2): %v", err)
-	}
-	if testing.Verbose() {
-		t.Log("Testing ListAllValues with all elements deleted")
 	}
 	got := c.ListAllValues()
 	if len(got) != 0 {
@@ -472,9 +439,6 @@ func TestRingListAllKeys_AllDeleted(t *testing.T) {
 	if err := c.Del(2); err != nil {
 		t.Errorf("unexpected error in Del(2): %v", err)
 	}
-	if testing.Verbose() {
-		t.Log("Testing ListAllKeys with all elements deleted")
-	}
 	got := c.ListAllKeys()
 	if len(got) != 0 {
 		t.Errorf("expected 0 keys, but got %d", len(got))
@@ -491,15 +455,36 @@ func TestRingAllIterator_AllDeleted(t *testing.T) {
 	if err := c.Del(2); err != nil {
 		t.Errorf("unexpected error in Del(2): %v", err)
 	}
-	if testing.Verbose() {
-		t.Log("Testing All iterator with all elements deleted")
-	}
-	iter := c.All()
 	count := 0
-	for range iter {
+	for range c.All() {
 		count++
 	}
 	if count != 0 {
 		t.Errorf("expected 0 items from iterator, but got %d", count)
+	}
+}
+
+
+func TestRingAllIterator_Break(t *testing.T) {
+	c := NewRingBuffer[int, int](10)
+	for i := 1; i <= 10; i++ {
+		c.Set(i, i)
+	}
+
+	count := 0
+	for i, j := range c.All() {
+		count++
+		if i != j {
+			t.Errorf("expected k==v, but got k=%d, v=%d", i, j)
+		}
+		if i != count {
+			t.Errorf("expected i==count, but got i=%d, count=%d", i, count)
+		}
+		if count == 5 {
+			break
+		}
+	}
+	if count != 5 {
+		t.Errorf("expected 5 items from iterator, but got %d", count)
 	}
 }

--- a/ring_test.go
+++ b/ring_test.go
@@ -142,3 +142,340 @@ func TestRingListAll(t *testing.T) {
 		}
 	}
 }
+
+func TestRingListAllValues(t *testing.T) {
+	c := NewRingBuffer[int, int](10)
+
+	// This will emulate the expected behavior of the ring buffer.
+	slice := make([]int, 0, 10)
+
+	for i := 0; i < 10000; i++ {
+		c.Set(i, i)
+
+		slice = append(slice, i)
+		if len(slice) > 10 {
+			slice = slice[1:]
+		}
+
+		if rand.Intn(10) == 0 {
+			// Randomly remove an item from the ring buffer.
+			toDelIdx := rand.Intn(len(slice))
+			toDelKey := slice[toDelIdx]
+			c.Del(toDelKey)
+			// Mark item as deleted in the slice.
+			slice[toDelIdx] = -1
+		}
+
+		expectedValues := make([]int, 0, len(slice))
+		for _, v := range slice {
+			if v == -1 {
+				continue
+			}
+			expectedValues = append(expectedValues, v)
+		}
+
+		gotValues := c.ListAllValues()
+		if len(gotValues) != len(expectedValues) {
+			t.Fatalf("expected %d values, but got %d", len(expectedValues), len(gotValues))
+		}
+
+		for j, val := range gotValues {
+			if val != expectedValues[j] {
+				t.Fatalf(
+					"expected value %d, but got %d",
+					expectedValues[j], val,
+				)
+			}
+		}
+	}
+}
+
+func TestRingListAllKeys(t *testing.T) {
+	c := NewRingBuffer[int, int](10)
+
+	// This will emulate the expected behavior of the ring buffer.
+	slice := make([]int, 0, 10)
+
+	for i := 0; i < 10000; i++ {
+		c.Set(i, i)
+
+		slice = append(slice, i)
+		if len(slice) > 10 {
+			slice = slice[1:]
+		}
+
+		if rand.Intn(10) == 0 {
+			// Randomly remove an item from the ring buffer.
+			toDelIdx := rand.Intn(len(slice))
+			toDelKey := slice[toDelIdx]
+			c.Del(toDelKey)
+			// Mark item as deleted in the slice.
+			slice[toDelIdx] = -1
+		}
+
+		expectedKeys := make([]int, 0, len(slice))
+		for _, v := range slice {
+			if v == -1 {
+				continue
+			}
+			expectedKeys = append(expectedKeys, v)
+		}
+
+		gotKeys := c.ListAllKeys()
+		if len(gotKeys) != len(expectedKeys) {
+			t.Fatalf("expected %d keys, but got %d", len(expectedKeys), len(gotKeys))
+		}
+
+		for j, key := range gotKeys {
+			if key != expectedKeys[j] {
+				t.Fatalf(
+					"expected key %d, but got %d",
+					expectedKeys[j], key,
+				)
+			}
+		}
+	}
+}
+
+func TestRingAllIterator(t *testing.T) {
+	c := NewRingBuffer[int, int](10)
+
+	// This will emulate the expected behavior of the ring buffer.
+	slice := make([]int, 0, 10)
+
+	for i := 0; i < 10000; i++ {
+		c.Set(i, i)
+
+		slice = append(slice, i)
+		if len(slice) > 10 {
+			slice = slice[1:]
+		}
+
+		if rand.Intn(10) == 0 {
+			// Randomly remove an item from the ring buffer.
+			toDelIdx := rand.Intn(len(slice))
+			toDelKey := slice[toDelIdx]
+			c.Del(toDelKey)
+			// Mark item as deleted in the slice.
+			slice[toDelIdx] = -1
+		}
+
+		expectedItems := make([]BufferRec[int, int], 0, len(slice))
+		for _, v := range slice {
+			if v == -1 {
+				continue
+			}
+			expectedItems = append(expectedItems, BufferRec[int, int]{K: v, V: v})
+		}
+
+		var gotItems []BufferRec[int, int]
+		for k, v := range c.All() {
+			gotItems = append(gotItems, BufferRec[int, int]{K: k, V: v})
+		}
+
+		if len(gotItems) != len(expectedItems) {
+			t.Fatalf("expected %d items from iterator, but got %d", len(expectedItems), len(gotItems))
+		}
+
+		for j, item := range gotItems {
+			if item.K != expectedItems[j].K || item.V != expectedItems[j].V {
+				t.Fatalf(
+					"iterator: expected item %d:%d, but got %d:%d",
+					expectedItems[j].K, expectedItems[j].V,
+					item.K, item.V,
+				)
+			}
+		}
+	}
+}
+
+func TestRingListAll_Empty(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+
+	if testing.Verbose() {
+		t.Log("Testing ListAll on an empty buffer")
+	}
+
+	got := c.ListAll()
+	if len(got) != 0 {
+		t.Errorf("expected 0 items, but got %d", len(got))
+	}
+}
+
+func TestRingListAllValues_Empty(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	if testing.Verbose() {
+		t.Log("Testing ListAllValues on an empty buffer")
+	}
+	got := c.ListAllValues()
+	if len(got) != 0 {
+		t.Errorf("expected 0 values, but got %d", len(got))
+	}
+}
+
+func TestRingListAllKeys_Empty(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	if testing.Verbose() {
+		t.Log("Testing ListAllKeys on an empty buffer")
+	}
+	got := c.ListAllKeys()
+	if len(got) != 0 {
+		t.Errorf("expected 0 keys, but got %d", len(got))
+	}
+}
+
+func TestRingAllIterator_Empty(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	if testing.Verbose() {
+		t.Log("Testing All iterator on an empty buffer")
+	}
+	iter := c.All()
+	count := 0
+	for range iter {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 items from iterator, but got %d", count)
+	}
+}
+
+func TestRingListAll_OneElement(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	c.Set(1, 10)
+	if testing.Verbose() {
+		t.Log("Testing ListAll with one element")
+	}
+
+	expected := []BufferRec[int, int]{{K: 1, V: 10}}
+	got := c.ListAll()
+	if len(got) != len(expected) {
+		t.Errorf("expected %d items, but got %d", len(expected), len(got))
+	}
+	for i, item := range got {
+		if item.K != expected[i].K || item.V != expected[i].V {
+			t.Errorf("expected item %d:%d, but got %d:%d", expected[i].K, expected[i].V, item.K, item.V)
+		}
+	}
+}
+
+func TestRingListAllValues_OneElement(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	c.Set(1, 10)
+	if testing.Verbose() {
+		t.Log("Testing ListAllValues with one element")
+	}
+	expected := []int{10}
+	got := c.ListAllValues()
+	if len(got) != len(expected) {
+		t.Errorf("expected %d values, but got %d", len(expected), len(got))
+	}
+	for i, val := range got {
+		if val != expected[i] {
+			t.Errorf("expected value %d, but got %d", expected[i], val)
+		}
+	}
+}
+
+func TestRingListAllKeys_OneElement(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	c.Set(1, 10)
+	if testing.Verbose() {
+		t.Log("Testing ListAllKeys with one element")
+	}
+	expected := []int{1}
+	got := c.ListAllKeys()
+	if len(got) != len(expected) {
+		t.Errorf("expected %d keys, but got %d", len(expected), len(got))
+	}
+	for i, key := range got {
+		if key != expected[i] {
+			t.Errorf("expected key %d, but got %d", expected[i], key)
+		}
+	}
+}
+
+func TestRingAllIterator_OneElement(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	c.Set(1, 10)
+	if testing.Verbose() {
+		t.Log("Testing All iterator with one element")
+	}
+	expectedItems := []BufferRec[int, int]{{K: 1, V: 10}}
+	iter := c.All()
+	var gotItems []BufferRec[int, int]
+	for k, v := range iter {
+		gotItems = append(gotItems, BufferRec[int, int]{K: k, V: v})
+	}
+	if len(gotItems) != len(expectedItems) {
+		t.Errorf("expected %d items from iterator, but got %d", len(expectedItems), len(gotItems))
+	}
+	for j, item := range gotItems {
+		if item.K != expectedItems[j].K || item.V != expectedItems[j].V {
+			t.Errorf("iterator: expected item %d:%d, but got %d:%d", expectedItems[j].K, expectedItems[j].V, item.K, item.V)
+		}
+	}
+}
+
+func TestRingListAll_AllDeleted(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	c.Set(1, 10)
+	c.Set(2, 20)
+	c.Del(1)
+	c.Del(2)
+	if testing.Verbose() {
+		t.Log("Testing ListAll with all elements deleted")
+	}
+	got := c.ListAll()
+	if len(got) != 0 {
+		t.Errorf("expected 0 items, but got %d", len(got))
+	}
+}
+
+func TestRingListAllValues_AllDeleted(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	c.Set(1, 10)
+	c.Set(2, 20)
+	c.Del(1)
+	c.Del(2)
+	if testing.Verbose() {
+		t.Log("Testing ListAllValues with all elements deleted")
+	}
+	got := c.ListAllValues()
+	if len(got) != 0 {
+		t.Errorf("expected 0 values, but got %d", len(got))
+	}
+}
+
+func TestRingListAllKeys_AllDeleted(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	c.Set(1, 10)
+	c.Set(2, 20)
+	c.Del(1)
+	c.Del(2)
+	if testing.Verbose() {
+		t.Log("Testing ListAllKeys with all elements deleted")
+	}
+	got := c.ListAllKeys()
+	if len(got) != 0 {
+		t.Errorf("expected 0 keys, but got %d", len(got))
+	}
+}
+
+func TestRingAllIterator_AllDeleted(t *testing.T) {
+	c := NewRingBuffer[int, int](5)
+	c.Set(1, 10)
+	c.Set(2, 20)
+	c.Del(1)
+	c.Del(2)
+	if testing.Verbose() {
+		t.Log("Testing All iterator with all elements deleted")
+	}
+	iter := c.All()
+	count := 0
+	for range iter {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 items from iterator, but got %d", count)
+	}
+}


### PR DESCRIPTION
Adding new functions that allow access to the `RingBuffer` contents in FIFO order:
* `ListAll` returns all key-value pairs in the cache in the order they were added.
* `ListAllValues` returns all values in the cache in the order they were added.
* `ListAllKeys` returns all keys in the cache in the order they were added.
* `All` is a (read-only) iterator over all key-value pairs in the cache.