### PR TITLE
allow KVCache wrapping

### DIFF
--- a/locker.go
+++ b/locker.go
@@ -128,13 +128,16 @@ func (tx *Tx[K, V]) Len() int {
 	return tx.cache.Len()
 }
 
-// ListByPrefix should only be called if underlying cache is KV.
-// Otherwise it will panic.
+type listerByPrefix[V any] interface {
+	ListByPrefix(prefix string) ([]V, error)
+}
+
+// ListByPrefix should only be called if underlying cache supports ListByPrefix.
 func (tx *Tx[K, V]) ListByPrefix(prefix string) ([]V, error) {
 	if atomic.LoadInt32(&tx.unlocked) == 1 {
 		panic("cannot use unlocked transaction")
 	}
-	kv, ok := any(tx.cache).(*KV[V])
+	kv, ok := any(tx.cache).(listerByPrefix[V])
 	if !ok {
 		panic("cache does not support ListByPrefix")
 	}

--- a/locker_test.go
+++ b/locker_test.go
@@ -185,3 +185,24 @@ func TestLockerListByPrefix(t *testing.T) {
 
 	compareSlice(t, expected, actual)
 }
+
+func TestLockerListByPrefixCache(t *testing.T) {
+	imp := NewLocker(NewKVCache[string, string]())
+	tx := imp.Lock()
+	defer tx.Unlock()
+
+	tx.Set("test9", "test9")
+	tx.Set("test2", "test2")
+	tx.Set("test1", "test1")
+	tx.Set("test3", "test3")
+
+	_ = tx.Del("test2")
+
+	expected := []string{"test1", "test3", "test9"}
+	actual, err := tx.ListByPrefix("test")
+	if err != nil {
+		t.Errorf("unexpected error in ListByPrefix: %v", err)
+	}
+
+	compareSlice(t, expected, actual)
+}

--- a/updater.go
+++ b/updater.go
@@ -131,7 +131,7 @@ func (u *Updater[K, V]) Len() int {
 	return u.cache.Len()
 }
 
-// ListByPrefix should only be called if underlying cache is KV.
+// ListByPrefix should only be called if underlying cache supports ListByPrefix.
 // Otherwise it will panic.
 func (u *Updater[K, V]) ListByPrefix(prefix string) ([]V, error) {
 	kv, ok := any(u.cache).(listerByPrefix[V])

--- a/updater.go
+++ b/updater.go
@@ -134,7 +134,7 @@ func (u *Updater[K, V]) Len() int {
 // ListByPrefix should only be called if underlying cache is KV.
 // Otherwise it will panic.
 func (u *Updater[K, V]) ListByPrefix(prefix string) ([]V, error) {
-	kv, ok := any(u.cache).(*KV[V])
+	kv, ok := any(u.cache).(listerByPrefix[V])
 	if !ok {
 		panic("cache does not support ListByPrefix")
 	}

--- a/updater_test.go
+++ b/updater_test.go
@@ -315,3 +315,22 @@ func TestHighInflightContention(t *testing.T) {
 		t.Error("timeout")
 	}
 }
+
+func TestUpdaterListByPrefixCache(t *testing.T) {
+	imp := NewCacheUpdater[string, string](NewKVCache[string, string](), updateFn, 2)
+
+	imp.Set("test9", "test9")
+	imp.Set("test2", "test2")
+	imp.Set("test1", "test1")
+	imp.Set("test3", "test3")
+
+	_ = imp.Del("test2")
+
+	expected := []string{"test1", "test3", "test9"}
+	actual, err := imp.ListByPrefix("test")
+	if err != nil {
+		t.Errorf("unexpected error in ListByPrefix: %v", err)
+	}
+
+	compareSlice(t, expected, actual)
+}


### PR DESCRIPTION
allow KVCache ListByPrefix to be accessed from Locker and Updater wrappers