### PR TITLE
add onEvict callback for TTLCache

### DIFF
--- a/map_ttl.go
+++ b/map_ttl.go
@@ -31,6 +31,7 @@ type MapTTLCache[K comparable, V any] struct {
 	data    map[K]ttlRec[K, V]
 	mux     sync.RWMutex
 	ttl     time.Duration
+	// TODO: replace with sync.Test
 	now     func() time.Time
 	onEvict onEvictFunc[K, V]
 	tail    K


### PR DESCRIPTION
Add `func (c *MapTTLCache[K, V]) OnEvict(f onEvictFunc[K, V])` function to set a callback on `MapTTLCache` to be called on each record evicted from the cache due to TTL expiration.