### PR TITLE
Clear function to remove all elements w/o reallocating the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Implementations are as simple as possible to be predictable in max latency, memo
 
 ## Examples
 
-Interface is quite simple with seven methods: `Set`, `Get`, `Del`, `SetIfPresent`, `Clear`, `Snapshot` and `Len`. Here's a quick example for a ring buffer holding 10k records.
+Interface is quite simple with eight methods: `Set`, `Get`, `Del`, `SetIfPresent`, `SetIfAbsent`, `Clear`, `Snapshot` and `Len`. Here's a quick example for a ring buffer holding 10k records.
 
 ```go
 package main

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Implementations are as simple as possible to be predictable in max latency, memo
 
 ## Examples
 
-Interface is quite simple with six methods: `Set`, `Get`, `Del`, `SetIfPresent`, `Snapshot` and `Len`. Here's a quick example for a ring buffer holding 10k records.
+Interface is quite simple with seven methods: `Set`, `Get`, `Del`, `SetIfPresent`, `Clear`, `Snapshot` and `Len`. Here's a quick example for a ring buffer holding 10k records.
 
 ```go
 package main
@@ -66,6 +66,11 @@ Please be aware that it is a shallow copy, so if your cache value type contains 
 
     fmt.Println(c.Snapshot())
 ```
+
+## Clear
+
+All cache implementations and wrappers provide `Clear` function that removes all values from the cache.
+Please notice that `Clear` does not free the memory allocated by the container itself to reduce allocations if you intend to reuse the cache after clearing. If you want to free the memory, you can just create a new cache object and discard the old one.
 
 ## Wrappers
 

--- a/clear_specific_test.go
+++ b/clear_specific_test.go
@@ -1,0 +1,221 @@
+package geche
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestKVCacheClearSpecific(t *testing.T) {
+	cache := NewKVCache[string, string]()
+	cache.Set("foo", "bar")
+	cache.Set("baz", "qux")
+
+	if cache.Len() != 2 {
+		t.Fatalf("expected length 2, got %d", cache.Len())
+	}
+
+	oldValuesCap := cap(cache.values)
+	oldFreelistCap := cap(cache.freelist)
+	oldTrieChildrenCap := cap(cache.trie.children)
+
+	cache.Clear()
+
+	if cache.Len() != 0 {
+		t.Errorf("expected length 0, got %d", cache.Len())
+	}
+
+	if cap(cache.values) != oldValuesCap {
+		t.Errorf("expected values capacity %d, got %d", oldValuesCap, cap(cache.values))
+	}
+	if cap(cache.freelist) != oldFreelistCap {
+		t.Errorf("expected freelist capacity %d, got %d", oldFreelistCap, cap(cache.freelist))
+	}
+	if cap(cache.trie.children) != oldTrieChildrenCap {
+		t.Errorf("expected trie children capacity %d, got %d", oldTrieChildrenCap, cap(cache.trie.children))
+	}
+
+	if len(cache.values) != 0 {
+		t.Errorf("expected values len 0, got %d", len(cache.values))
+	}
+	if len(cache.freelist) != 0 {
+		t.Errorf("expected freelist len 0, got %d", len(cache.freelist))
+	}
+	if len(cache.trie.children) != 0 {
+		t.Errorf("expected trie children len 0, got %d", len(cache.trie.children))
+	}
+	if cache.trie.terminal {
+		t.Error("expected trie terminal to be false")
+	}
+	if cache.trie.valueIndex != 0 {
+		t.Errorf("expected trie valueIndex 0, got %d", cache.trie.valueIndex)
+	}
+
+	// Verify we can insert new values after clear
+	cache.Set("a", "b")
+	val, err := cache.Get("a")
+	if err != nil {
+		t.Errorf("unexpected error after clear and set: %v", err)
+	}
+	if val != "b" {
+		t.Errorf("expected b, got %q", val)
+	}
+}
+
+func TestUpdaterClearSpecific(t *testing.T) {
+	updateFn := func(key string) (string, error) {
+		return key, nil
+	}
+
+	u := NewCacheUpdater(
+		NewMapCache[string, string](),
+		updateFn,
+		2,
+	)
+
+	u.Set("key1", "val1")
+	u.Set("key2", "val2")
+
+	if u.Len() != 2 {
+		t.Fatalf("expected length 2, got %d", u.Len())
+	}
+
+	u.Clear()
+
+	if u.Len() != 0 {
+		t.Errorf("expected length 0, got %d", u.Len())
+	}
+
+	_, err := u.cache.Get("key1")
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound for key1 in underlying cache, got %v", err)
+	}
+
+	u.Set("key3", "val3")
+	val, err := u.Get("key3")
+	if err != nil {
+		t.Errorf("unexpected error in Get after post-clear Set: %v", err)
+	}
+	if val != "val3" {
+		t.Errorf("expected val3, got %q", val)
+	}
+}
+
+func TestTxClearSpecific(t *testing.T) {
+	locker := NewLocker(NewMapCache[string, string]())
+
+	// Test writable Tx Clear
+	tx := locker.Lock()
+	tx.Set("key1", "val1")
+	tx.Clear()
+	if tx.Len() != 0 {
+		t.Errorf("expected length 0, got %d", tx.Len())
+	}
+
+	tx.Set("key3", "val3")
+	val, err := tx.Get("key3")
+	if err != nil {
+		t.Errorf("unexpected error in Get after post-clear Set: %v", err)
+	}
+	if val != "val3" {
+		t.Errorf("expected val3, got %q", val)
+	}
+	tx.Unlock()
+
+	// Test read-only Tx Clear (should panic)
+	tx2 := locker.RLock()
+	panics := func(f func()) (panicked bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		f()
+		return
+	}
+
+	if !panics(func() { tx2.Clear() }) {
+		t.Error("expected Clear on read-only transaction to panic")
+	}
+	tx2.Unlock()
+
+	// Test unlocked Tx Clear (should panic)
+	if !panics(func() { tx.Clear() }) {
+		t.Error("expected Clear on already unlocked transaction to panic")
+	}
+}
+
+func TestMapTTLCacheClearSpecific(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := NewMapTTLCache[string, string](ctx, time.Minute, time.Minute)
+	c.Set("key1", "val1")
+	c.Set("key2", "val2")
+
+	if c.head != "key1" || c.tail != "key2" {
+		t.Fatalf("unexpected head/tail: %q/%q", c.head, c.tail)
+	}
+
+	c.Clear()
+
+	if c.Len() != 0 {
+		t.Errorf("expected length 0, got %d", c.Len())
+	}
+	if c.head != "" {
+		t.Errorf("expected empty head, got %q", c.head)
+	}
+	if c.tail != "" {
+		t.Errorf("expected empty tail, got %q", c.tail)
+	}
+
+	c.Set("k3", "v3")
+	if c.head != "k3" || c.tail != "k3" {
+		t.Errorf("unexpected head/tail after post-clear Set: %q/%q", c.head, c.tail)
+	}
+	val, err := c.Get("k3")
+	if err != nil {
+		t.Errorf("unexpected error in Get after post-clear Set: %v", err)
+	}
+	if val != "v3" {
+		t.Errorf("expected v3, got %q", val)
+	}
+}
+
+func TestRingBufferClearSpecific(t *testing.T) {
+	c := NewRingBuffer[string, string](3)
+	c.Set("k1", "v1")
+	c.Set("k2", "v2")
+
+	if c.Len() != 2 {
+		t.Fatalf("expected length 2, got %d", c.Len())
+	}
+
+	c.Clear()
+
+	if c.Len() != 0 {
+		t.Errorf("expected length 0, got %d", c.Len())
+	}
+
+	if c.head != 0 {
+		t.Errorf("expected head 0, got %d", c.head)
+	}
+
+	for i, item := range c.data {
+		if !item.empty {
+			t.Errorf("expected item %d to be empty", i)
+		}
+		if item.K != "" || item.V != "" {
+			t.Errorf("expected item %d to be zeroed out, got key: %q, val: %q", i, item.K, item.V)
+		}
+	}
+
+	c.Set("k3", "v3")
+	val, err := c.Get("k3")
+	if err != nil {
+		t.Errorf("unexpected error in Get after post-clear Set: %v", err)
+	}
+	if val != "v3" {
+		t.Errorf("expected v3, got %q", val)
+	}
+}

--- a/common_test.go
+++ b/common_test.go
@@ -216,6 +216,43 @@ func testDelOdd(t *testing.T, imp Geche[string, string]) {
 	}
 }
 
+func testClear(t *testing.T, imp Geche[string, string]) {
+	imp.Set("key1", "value1")
+	imp.Set("key2", "value2")
+	if imp.Len() != 2 {
+		t.Errorf("expected length 2, got %d", imp.Len())
+	}
+
+	imp.Clear()
+
+	if imp.Len() != 0 {
+		t.Errorf("expected length 0 after Clear, got %d", imp.Len())
+	}
+
+	_, err := imp.Get("key1")
+	if err != ErrNotFound {
+		t.Errorf("expected key1 to be deleted after Clear, got error: %v", err)
+	}
+
+	_, err = imp.Get("key2")
+	if err != ErrNotFound {
+		t.Errorf("expected key2 to be deleted after Clear, got error: %v", err)
+	}
+
+	// Verify we can set and get values after clear.
+	imp.Set("key3", "value3")
+	if imp.Len() != 1 {
+		t.Errorf("expected length 1 after post-clear Set, got %d", imp.Len())
+	}
+	val, err := imp.Get("key3")
+	if err != nil {
+		t.Errorf("unexpected error in Get after post-clear Set: %v", err)
+	}
+	if val != "value3" {
+		t.Errorf("expected value3, got %q", val)
+	}
+}
+
 // TestCommon runs a common set of tests on all implementations of Geche interface.
 func TestCommon(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -259,6 +296,19 @@ func TestCommon(t *testing.T) {
 				)
 			},
 		},
+		{"KVCache", func() Geche[string, string] { return NewKVCache[string, string]() }},
+		{"LockerKVCache", func() Geche[string, string] {
+			return NewLocker[string, string](NewKVCache[string, string]()).Lock()
+		}},
+		{
+			"ShardedKVCache", func() Geche[string, string] {
+				return NewSharded[string](
+					func() Geche[string, string] { return NewKVCache[string, string]() },
+					0,
+					&StringMapper{},
+				)
+			},
+		},
 	}
 
 	tab := []struct {
@@ -274,6 +324,7 @@ func TestCommon(t *testing.T) {
 		{"SetIfPresentGet", testSetIfPresentThenGet},
 		{"SetSetIfAbsentGet", testSetThenSetIfAbsentThenGet},
 		{"SetIfAbsentGet", testSetIfAbsentThenGet},
+		{"Clear", testClear},
 	}
 	for _, ci := range caches {
 		for _, tc := range tab {

--- a/doc.go
+++ b/doc.go
@@ -17,4 +17,6 @@ type Geche[K comparable, V any] interface {
 	Del(K) error
 	Snapshot() map[K]V
 	Len() int
+	// Clear removes all elements from the cache.
+	Clear()
 }

--- a/kv.go
+++ b/kv.go
@@ -330,6 +330,17 @@ func (kv *KV[V]) Len() int {
 	return kv.data.Len()
 }
 
+// Clear removes all elements from the cache and resets the trie.
+func (kv *KV[V]) Clear() {
+	kv.mux.Lock()
+	defer kv.mux.Unlock()
+
+	kv.data.Clear()
+	kv.trie = &trieNode{
+		down: make(map[byte]*trieNode),
+	}
+}
+
 func (kv *KV[V]) set(key string, value V) {
 	kv.data.Set(key, value)
 

--- a/kv_cache.go
+++ b/kv_cache.go
@@ -179,14 +179,11 @@ func (kv *KVCache[K, V]) AllByPrefix(prefix string) iter.Seq2[string, V] {
 					// The full path to `child` is `pathPrefix` + `child.b`.
 					path = append(pathPrefix, child.b...)
 					node = child
-					goto start_dfs
+					break
 				}
 			}
-			// This is for when the prefix matches a node path exactly
-			path = pathPrefix
 		}
 
-	start_dfs:
 		// 2. Stack-based DFS from the found node.
 		if node.terminal {
 			if !yield(string(path), kv.values[node.valueIndex]) {
@@ -250,6 +247,23 @@ func (kv *KVCache[K, V]) Snapshot() map[string]V {
 // Len returns the number of the values in the cache.
 func (kv *KVCache[K, V]) Len() int {
 	return max(0, len(kv.values)-len(kv.freelist))
+}
+
+// Clear removes all elements from the cache while preserving allocated capacities.
+func (kv *KVCache[K, V]) Clear() {
+	kv.mux.Lock()
+	defer kv.mux.Unlock()
+
+	clear(kv.values)
+	kv.values = kv.values[:0]
+
+	clear(kv.freelist)
+	kv.freelist = kv.freelist[:0]
+
+	clear(kv.trie.children)
+	kv.trie.children = kv.trie.children[:0]
+	kv.trie.terminal = false
+	kv.trie.valueIndex = 0
 }
 
 // --- Internal Trie Helpers ---
@@ -394,21 +408,6 @@ func (kv *KVCache[K, V]) deleteValueAtIndex(idx int) {
 func (kv *KVCache[K, V]) delete(key string) error {
 	keyBytes := []byte(key)
 
-	// Stack-based deletion to avoid recursion
-	type stackEntry struct {
-		node     *trieCacheNode
-		keyPart  []byte
-		childIdx int // index of child to check, -1 if not yet determined
-		parent   *trieCacheNode
-	}
-
-	stack := []stackEntry{{
-		node:     kv.trie,
-		keyPart:  keyBytes,
-		childIdx: -1,
-		parent:   nil,
-	}}
-
 	// Track path for cleanup phase
 	type pathEntry struct {
 		node     *trieCacheNode
@@ -417,37 +416,37 @@ func (kv *KVCache[K, V]) delete(key string) error {
 	}
 	var path []pathEntry
 
-	// Phase 1: Navigate to the target node
-	for len(stack) > 0 {
-		top := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
+	node := kv.trie
+	keyPart := keyBytes
 
-		if len(top.keyPart) == 0 {
+	// Navigate to the target node
+	for {
+		if len(keyPart) == 0 {
 			// Reached the target node
-			if top.node.terminal {
-				top.node.terminal = false
-				kv.deleteValueAtIndex(top.node.valueIndex)
+			if node.terminal {
+				node.terminal = false
+				kv.deleteValueAtIndex(node.valueIndex)
 
 				// Phase 2: Cleanup - walk back and remove childless non-terminal nodes
 				for i := len(path) - 1; i >= 0; i-- {
-					node := path[i].node
-					parent := path[i].parent
+					pNode := path[i].node
+					pParent := path[i].parent
 					childIdx := path[i].childIdx
 
-					if len(node.children) == 0 && !node.terminal {
+					if len(pNode.children) == 0 && !pNode.terminal {
 						// Case 1: Delete empty non-terminal node
 						// Remove child from slice
-						copy(parent.children[childIdx:], parent.children[childIdx+1:])
-						parent.children[len(parent.children)-1] = trieCacheNode{}
-						parent.children = parent.children[:len(parent.children)-1]
-					} else if len(node.children) == 1 && !node.terminal {
+						copy(pParent.children[childIdx:], pParent.children[childIdx+1:])
+						pParent.children[len(pParent.children)-1] = trieCacheNode{}
+						pParent.children = pParent.children[:len(pParent.children)-1]
+					} else if len(pNode.children) == 1 && !pNode.terminal {
 						// Case 2: Merge node with its single child
-						child := node.children[0]
+						child := pNode.children[0]
 
-						node.b = append(node.b, child.b...)
-						node.terminal = child.terminal
-						node.valueIndex = child.valueIndex
-						node.children = child.children
+						pNode.b = append(pNode.b, child.b...)
+						pNode.terminal = child.terminal
+						pNode.valueIndex = child.valueIndex
+						pNode.children = child.children
 					} else {
 						// Node is stable (has >1 children or is terminal), stop cleanup
 						break
@@ -457,14 +456,14 @@ func (kv *KVCache[K, V]) delete(key string) error {
 			return nil
 		}
 
-		idx, found := top.node.findChild(top.keyPart[0])
+		idx, found := node.findChild(keyPart[0])
 		if !found {
 			// Key doesn't exist, nothing to delete
 			return nil
 		}
 
-		child := &top.node.children[idx]
-		common := commonPrefixLen(child.b, top.keyPart)
+		child := &node.children[idx]
+		common := commonPrefixLen(child.b, keyPart)
 
 		if common != len(child.b) {
 			// Partial match, key doesn't exist
@@ -474,20 +473,14 @@ func (kv *KVCache[K, V]) delete(key string) error {
 		// Record path for cleanup
 		path = append(path, pathEntry{
 			node:     child,
-			parent:   top.node,
+			parent:   node,
 			childIdx: idx,
 		})
 
 		// Continue with remaining key
-		stack = append(stack, stackEntry{
-			node:     child,
-			keyPart:  top.keyPart[common:],
-			childIdx: -1,
-			parent:   top.node,
-		})
+		node = child
+		keyPart = keyPart[common:]
 	}
-
-	return nil
 }
 
 func (kv *KVCache[K, V]) dfs(node *trieCacheNode, currentPath []byte) ([]V, error) {

--- a/kv_cache.go
+++ b/kv_cache.go
@@ -143,6 +143,8 @@ func (kv *KVCache[K, V]) ListByPrefix(prefix string) ([]V, error) {
 // AllByPrefix returns an (read only) iterator over values with keys starting with the given prefix.
 // The iterator yields key-value pairs.
 // Attempting to modify the cache while iterating will lead to a deadlock.
+// Iterator holds RLock on the cache for the whole iteration, so it is not recommended
+// to use it for long-running loops if cache can be accessed concurrently.
 func (kv *KVCache[K, V]) AllByPrefix(prefix string) iter.Seq2[string, V] {
 	return func(yield func(string, V) bool) {
 		kv.mux.RLock()
@@ -234,7 +236,7 @@ func (kv *KVCache[K, V]) Snapshot() map[string]V {
 	kv.mux.RLock()
 	defer kv.mux.RUnlock()
 
-	res := make(map[string]V, kv.Len())
+	res := make(map[string]V, kv.len())
 
 	seq := kv.AllByPrefix("")
 	seq(func(k string, v V) bool {
@@ -244,9 +246,16 @@ func (kv *KVCache[K, V]) Snapshot() map[string]V {
 	return res
 }
 
+func (kv *KVCache[K, V]) len() int {
+	return max(0, len(kv.values)-len(kv.freelist))
+}
+
 // Len returns the number of the values in the cache.
 func (kv *KVCache[K, V]) Len() int {
-	return max(0, len(kv.values)-len(kv.freelist))
+	kv.mux.RLock()
+	defer kv.mux.RUnlock()
+
+	return kv.len()
 }
 
 // Clear removes all elements from the cache while preserving allocated capacities.

--- a/kv_cache_test.go
+++ b/kv_cache_test.go
@@ -328,6 +328,17 @@ func TestKVCacheNonexist(t *testing.T) {
 		t.Errorf("unexpected len %d", len(got))
 	}
 
+	// Test partial match for prefix node where search has more characters but child does not match.
+	// This covers common < len(searchKey) && common < len(child.b) in ListByPrefix.
+	got, err = cache.ListByPrefix("tex")
+	if err != nil {
+		t.Fatalf("unexpected error in ListByPrefix: %v", err)
+	}
+
+	if len(got) > 0 {
+		t.Errorf("unexpected len %d", len(got))
+	}
+
 	if err := cache.Del("nonexistent"); err != nil {
 		t.Errorf("unexpected error in Del: %v", err)
 	}
@@ -794,6 +805,9 @@ func FuzzKVCacheMonkey(f *testing.F) {
 				// Since keys are random we expect a lot of Del to fail.
 				_ = cache.Del(cmd.key)
 				delete(golden, cmd.key)
+			case "Clear":
+				cache.Clear()
+				clear(golden)
 			}
 		}
 
@@ -1729,6 +1743,9 @@ func FuzzKVCacheMonkey_AllByPrefix(f *testing.F) {
 				// Since keys are random we expect a lot of Del to fail.
 				_ = cache.Del(cmd.key)
 				delete(golden, cmd.key)
+			case "Clear":
+				cache.Clear()
+				clear(golden)
 			}
 		}
 

--- a/kv_test.go
+++ b/kv_test.go
@@ -340,6 +340,7 @@ func (m *MockErrCache) SetIfAbsent(key string, value string) (string, bool)  { r
 func (m *MockErrCache) Del(key string) error                                 { return nil }
 func (m *MockErrCache) Snapshot() map[string]string                          { return nil }
 func (m *MockErrCache) Len() int                                             { return 0 }
+func (m *MockErrCache) Clear()                                               {}
 func (m *MockErrCache) Get(key string) (string, error) {
 	if key == "err" {
 		return "", errors.New("wow an error")
@@ -936,6 +937,9 @@ func FuzzMonkey(f *testing.F) {
 				// Since keys are random we expect a lot of Del to fail.
 				_ = kv.Del(cmd.key)
 				delete(golden, cmd.key)
+			case "Clear":
+				kv.Clear()
+				clear(golden)
 			}
 		}
 
@@ -987,9 +991,13 @@ func randTask(seed int64) []command {
 	r := rand.New(rand.NewSource(seed))
 
 	for i := 0; i < len(task); i++ {
-		task[i].action = "Set"
-		if r.Float64() < 0.1 {
+		p := r.Float64()
+		if p < 0.02 {
+			task[i].action = "Clear"
+		} else if p < 0.12 {
 			task[i].action = "Del"
+		} else {
+			task[i].action = "Set"
 		}
 		task[i].key = genRandomString(
 			r.Intn(taskMaxKeyLen-taskMinKeyLen) +

--- a/locker.go
+++ b/locker.go
@@ -138,6 +138,18 @@ func (tx *Tx[K, V]) Len() int {
 	return tx.cache.Len()
 }
 
+// Clear removes all elements from the cache.
+// Will panic if called on RLocked Tx or unlocked Tx.
+func (tx *Tx[K, V]) Clear() {
+	if atomic.LoadInt32(&tx.unlocked) == 1 {
+		panic("cannot use unlocked transaction")
+	}
+	if !tx.writable {
+		panic("cannot clear in read-only transaction")
+	}
+	tx.cache.Clear()
+}
+
 type listerByPrefix[V any] interface {
 	ListByPrefix(prefix string) ([]V, error)
 }

--- a/map.go
+++ b/map.go
@@ -95,3 +95,11 @@ func (c *MapCache[K, V]) Len() int {
 
 	return len(c.data)
 }
+
+// Clear removes all items from the cache.
+func (c *MapCache[K, V]) Clear() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	clear(c.data)
+}

--- a/map_ttl.go
+++ b/map_ttl.go
@@ -237,6 +237,16 @@ func (c *MapTTLCache[K, V]) Len() int {
 	return len(c.data)
 }
 
+// Clear removes all records from the cache.
+func (c *MapTTLCache[K, V]) Clear() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	clear(c.data)
+	c.head = c.zero
+	c.tail = c.zero
+}
+
 func (c *MapTTLCache[K, V]) set(key K, value V) {
 	ts := c.now()
 	val := ttlRec[K, V]{

--- a/ring.go
+++ b/ring.go
@@ -141,6 +141,18 @@ func (c *RingBuffer[K, V]) Len() int {
 	return len(c.index)
 }
 
+// Clear removes all items from the cache.
+func (c *RingBuffer[K, V]) Clear() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	for i := range c.data {
+		c.data[i] = BufferRec[K, V]{empty: true}
+	}
+	clear(c.index)
+	c.head = 0
+}
+
 // ListAll returns all key-value pairs in the cache in the order they were added.
 func (c *RingBuffer[K, V]) ListAll() []BufferRec[K, V] {
 	c.mux.RLock()

--- a/shard.go
+++ b/shard.go
@@ -123,3 +123,10 @@ func (s *Sharded[K, V]) Len() int {
 
 	return l
 }
+
+// Clear removes all elements from all underlying shards.
+func (s *Sharded[K, V]) Clear() {
+	for _, shard := range s.shards {
+		shard.Clear()
+	}
+}

--- a/updater.go
+++ b/updater.go
@@ -135,6 +135,14 @@ func (u *Updater[K, V]) Len() int {
 	return u.cache.Len()
 }
 
+// Clear removes all elements from the cache.
+func (u *Updater[K, V]) Clear() {
+	u.mux.Lock()
+	defer u.mux.Unlock()
+
+	u.cache.Clear()
+}
+
 // ListByPrefix should only be called if underlying cache supports ListByPrefix.
 // Otherwise it will panic.
 func (u *Updater[K, V]) ListByPrefix(prefix string) ([]V, error) {

--- a/updater_test.go
+++ b/updater_test.go
@@ -145,6 +145,46 @@ func TestUpdaterSetIfPresent(t *testing.T) {
 	}
 }
 
+func TestUpdaterSetIfAbsent(t *testing.T) {
+	u := NewCacheUpdater(
+		NewMapCache[string, string](),
+		updateFn,
+		2,
+	)
+
+	if u.Len() != 0 {
+		t.Errorf("expected length to be 0, but got %d", u.Len())
+	}
+
+	s, inserted := u.SetIfAbsent("test", "test")
+	if !inserted {
+		t.Error("expected to insert the value")
+	}
+
+	if s != "" {
+		t.Errorf("expected to get empty string, but got %q", s)
+	}
+
+	s, inserted = u.SetIfAbsent("test", "test2")
+	if inserted {
+		t.Error("expected to not insert the value")
+	}
+
+	if s != "test" {
+		t.Errorf("expected to get %q, but got %q", "test", s)
+	}
+
+	v, err := u.Get("test")
+	if err != nil {
+		t.Errorf("unexpected error in Get: %v", err)
+	}
+
+	if v != "test" {
+		t.Errorf("expected to get %q, but got %q", "test", v)
+	}
+}
+
+
 func TestUpdaterErr(t *testing.T) {
 	u := NewCacheUpdater[string, string](
 		NewMapCache[string, string](),

--- a/updater_test.go
+++ b/updater_test.go
@@ -27,7 +27,7 @@ func ExampleNewCacheUpdater() {
 
 	// Create a cache updater with updaterFunction
 	// that sets cache value equal to the key.
-	u := NewCacheUpdater[string, string](
+	u := NewCacheUpdater(
 		NewMapTTLCache[string, string](ctx, time.Minute, time.Minute),
 		updateFn,
 		2,
@@ -42,7 +42,7 @@ func ExampleNewCacheUpdater() {
 }
 
 func TestUpdaterScenario(t *testing.T) {
-	u := NewCacheUpdater[string, string](
+	u := NewCacheUpdater(
 		NewMapCache[string, string](),
 		updateFn,
 		2,
@@ -105,7 +105,7 @@ func TestUpdaterScenario(t *testing.T) {
 }
 
 func TestUpdaterSetIfPresent(t *testing.T) {
-	u := NewCacheUpdater[string, string](
+	u := NewCacheUpdater(
 		NewMapCache[string, string](),
 		updateFn,
 		2,
@@ -184,9 +184,42 @@ func TestUpdaterSetIfAbsent(t *testing.T) {
 	}
 }
 
+func TestUpdaterClear(t *testing.T) {
+	u := NewCacheUpdater(
+		NewMapCache[string, string](),
+		updateFn,
+		2,
+	)
+
+	u.Set("test1", "test1")
+	u.Set("test2", "test2")
+
+	if u.Len() != 2 {
+		t.Errorf("expected length to be 2, but got %d", u.Len())
+	}
+
+	u.Clear()
+
+	if u.Len() != 0 {
+		t.Errorf("expected length to be 0, but got %d", u.Len())
+	}
+
+	v, err := u.Get("test1")
+	if err != nil {
+		t.Error("expected ErrNotFound")
+	}
+
+	if v != "test1" {
+		t.Errorf("expected to get %q, but got %q", "test1", v)
+	}
+
+	if u.Len() != 1 {
+		t.Errorf("expected length to be 1, but got %d", u.Len())
+	}
+}
 
 func TestUpdaterErr(t *testing.T) {
-	u := NewCacheUpdater[string, string](
+	u := NewCacheUpdater(
 		NewMapCache[string, string](),
 		updateErrFn,
 		2,
@@ -236,7 +269,7 @@ func TestUpdaterConcurrent(t *testing.T) {
 
 	poolSize := 4
 
-	u := NewCacheUpdater[string, string](
+	u := NewCacheUpdater(
 		NewMapCache[string, string](),
 		updateFn,
 		poolSize,
@@ -299,7 +332,7 @@ func TestUpdaterConcurrent(t *testing.T) {
 }
 
 func TestUpdaterListByPrefix(t *testing.T) {
-	imp := NewCacheUpdater[string, string](NewKV[string](NewMapCache[string, string]()), updateFn, 2)
+	imp := NewCacheUpdater(NewKV[string](NewMapCache[string, string]()), updateFn, 2)
 
 	imp.Set("test9", "test9")
 	imp.Set("test2", "test2")
@@ -318,7 +351,7 @@ func TestUpdaterListByPrefix(t *testing.T) {
 }
 
 func TestUpdaterListByPrefixUnsupported(t *testing.T) {
-	imp := NewCacheUpdater[string, string](NewMapCache[string, string](), updateFn, 2)
+	imp := NewCacheUpdater(NewMapCache[string, string](), updateFn, 2)
 
 	if !panics(func() { _, _ = imp.ListByPrefix("test") }) {
 		t.Error("ListByPrefix expected to panic if underlying cache does not provide ListByPrefix")
@@ -326,7 +359,7 @@ func TestUpdaterListByPrefixUnsupported(t *testing.T) {
 }
 
 func TestHighInflightContention(t *testing.T) {
-	imp := NewCacheUpdater[string, string](NewMapCache[string, string](), func(key string) (string, error) {
+	imp := NewCacheUpdater(NewMapCache[string, string](), func(key string) (string, error) {
 		if rand.Float64() < 0.1 {
 			return "value", nil
 		}
@@ -357,7 +390,7 @@ func TestHighInflightContention(t *testing.T) {
 }
 
 func TestUpdaterListByPrefixCache(t *testing.T) {
-	imp := NewCacheUpdater[string, string](NewKVCache[string, string](), updateFn, 2)
+	imp := NewCacheUpdater(NewKVCache[string, string](), updateFn, 2)
 
 	imp.Set("test9", "test9")
 	imp.Set("test2", "test2")


### PR DESCRIPTION
When your usecase requires replacing the whole contents of the underlying geche container it would be nice to have an option to delete all elements without releasing allocated memory, so repopulating the cache won't result in massive number of allocations.
New `Clear` method does exactly this.